### PR TITLE
Split off errors from `OpcodeResolution`

### DIFF
--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -26,6 +26,7 @@ k256 = { version = "0.7.2", features = [
     "arithmetic",
 ] }
 indexmap = "1.7.0"
+thiserror = "1.0.21"
 
 [features]
 bn254 = ["acir_field/bn254"]

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -15,6 +15,7 @@ use blake2::digest::FixedOutput;
 use crate::pwg::{arithmetic::ArithmeticSolver, logic::LogicSolver};
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
+use thiserror::Error;
 
 // re-export acir
 pub use acir;
@@ -26,11 +27,14 @@ pub enum OpcodeResolution {
     Skip,     // Opcode cannot be solved
 }
 
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Error)]
 pub enum OpcodeResolutionError {
-    UnknownError(String),                  // Generic error
-    UnsupportedBlackBoxFunc(BlackBoxFunc), // Unsupported black box function
-    UnsatisfiedConstrain,                  // Opcode is not satisfied
+    #[error("{0}")]
+    UnknownError(String),
+    #[error("backend does not currently support the {0} opcode. ACVM does not currently fall back to arithmetic gates.")]
+    UnsupportedBlackBoxFunc(BlackBoxFunc),
+    #[error("could not satisfy all constraints")]
+    UnsatisfiedConstrain,
 }
 
 pub trait Backend: SmartContract + ProofSystemCompiler + PartialWitnessGenerator {}

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -3,6 +3,8 @@ use acir::native_types::Witness;
 use acir_field::FieldElement;
 use std::collections::BTreeMap;
 
+use crate::OpcodeResolution;
+
 pub struct LogicSolver;
 
 impl LogicSolver {
@@ -14,13 +16,13 @@ impl LogicSolver {
         result: Witness,
         num_bits: u32,
         is_xor_gate: bool,
-    ) -> bool {
+    ) -> OpcodeResolution {
         let w_l = initial_witness.get(a);
         let w_r = initial_witness.get(b);
 
         let (w_l_value, w_r_value) = match (w_l, w_r) {
             (Some(w_l_value), Some(w_r_value)) => (w_l_value, w_r_value),
-            (_, _) => return false,
+            (_, _) => return OpcodeResolution::Skip,
         };
 
         if is_xor_gate {
@@ -30,20 +32,20 @@ impl LogicSolver {
             let assignment = w_l_value.and(w_r_value, num_bits);
             initial_witness.insert(result, assignment);
         }
-        true
+        OpcodeResolution::Resolved
     }
 
     pub fn solve_and_gate(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gate: &BlackBoxFuncCall,
-    ) -> bool {
+    ) -> OpcodeResolution {
         let (a, b, result, num_bits) = extract_input_output(gate);
         LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, false)
     }
     pub fn solve_xor_gate(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gate: &BlackBoxFuncCall,
-    ) -> bool {
+    ) -> OpcodeResolution {
         let (a, b, result, num_bits) = extract_input_output(gate);
         LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, true)
     }


### PR DESCRIPTION
This implements the changes described in https://github.com/noir-lang/noir/pull/520#discussion_r1052624508.

This is sensible imo as 
- `OpcodeResolution` doesn't make sense for a circuit-level function such as `PartialWitnessGenerator.solve` (what does "Skip" mean when solving a circuit?)
- We can define error messages here in ACVM for the failure modes of solving the circuit. Callers then don't need to understand the reasoning behind all the `OpcodeResolution` variants to be able to separate success vs failure. 

I've lumped in a change to simplify `BlackBoxFuncCall` in the last commit which improves readability imo, happy to revert this if this is unwanted.