### PR TITLE
feat: Add Log Directive

### DIFF
--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use crate::{
     native_types::{Expression, Witness},
-    serialisation::{read_n, read_u16, read_u32, write_bytes, write_n, write_u16, write_u32},
+    serialisation::{read_n, read_u16, read_u32, write_bytes, write_u16, write_u32},
 };
 use serde::{Deserialize, Serialize};
 

--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 
 use crate::{
     native_types::{Expression, Witness},
-    serialisation::{read_n, read_u16, read_u32, write_bytes, write_u16, write_u32},
+    serialisation::{read_n, read_u16, read_u32, write_bytes, write_n, write_u16, write_u32},
 };
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +48,8 @@ pub enum Directive {
         b: Vec<Witness>,
         radix: u32,
     },
+
+    Log(LogInfo),
 }
 
 impl Directive {
@@ -58,6 +60,7 @@ impl Directive {
             Directive::Truncate { .. } => "truncate",
             Directive::OddRange { .. } => "odd_range",
             Directive::ToRadix { .. } => "to_radix",
+            Directive::Log { .. } => "log",
         }
     }
     fn to_u16(&self) -> u16 {
@@ -67,6 +70,7 @@ impl Directive {
             Directive::Truncate { .. } => 2,
             Directive::OddRange { .. } => 3,
             Directive::ToRadix { .. } => 4,
+            Directive::Log { .. } => 5,
         }
     }
 
@@ -116,6 +120,17 @@ impl Directive {
                 }
                 write_u32(&mut writer, *radix)?;
             }
+            Directive::Log(info) => match info {
+                LogInfo::FinalizedOutput(output_string) => {
+                    write_bytes(&mut writer, output_string.as_bytes())?;
+                }
+                LogInfo::WitnessOutput(witnesses) => {
+                    write_u32(&mut writer, witnesses.len() as u32)?;
+                    for w in witnesses {
+                        write_u32(&mut writer, w.witness_index())?;
+                    }
+                }
+            },
         };
 
         Ok(())
@@ -182,6 +197,14 @@ impl Directive {
             _ => Err(std::io::ErrorKind::InvalidData.into()),
         }
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+// If values are compile time and/or known during evaluation, we can form an output string during ACIR gen.
+// Otherwise, we must store witnesses whose values will be fetched during the PWG.
+pub enum LogInfo {
+    FinalizedOutput(String),
+    WitnessOutput(Vec<Witness>),
 }
 
 #[test]

--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -200,8 +200,10 @@ impl Directive {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-// If values are compile time and/or known during evaluation, we can form an output string during ACIR gen.
-// Otherwise, we must store witnesses whose values will be fetched during the PWG.
+// If values are compile time and/or known during
+// evaluation, we can form an output string during ACIR generation.
+// Otherwise, we must store witnesses whose values will
+// be fetched during the PWG stage.
 pub enum LogInfo {
     FinalizedOutput(String),
     WitnessOutput(Vec<Witness>),

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -164,18 +164,6 @@ impl std::fmt::Display for Opcode {
                     b.last().unwrap().witness_index(),
                 )
             }
-            // Opcode::Directive(Directive::Log { output_string, witnesses }) => {
-            //     if !witnesses.is_empty() {
-            //         write!(
-            //             f,
-            //             "Log: _{}..._{}",
-            //             witnesses.first().unwrap().witness_index(),
-            //             witnesses.last().unwrap().witness_index()
-            //         )
-            //     } else {
-            //         write!(f, "Log: {}", output_string)
-            //     }
-            // }
             Opcode::Directive(Directive::Log(info)) => match info {
                 LogInfo::FinalizedOutput(output_string) => write!(f, "Log: {}", output_string),
                 LogInfo::WitnessOutput(witnesses) => write!(

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -165,7 +165,7 @@ impl std::fmt::Display for Opcode {
                 )
             }
             Opcode::Directive(Directive::Log(info)) => match info {
-                LogInfo::FinalizedOutput(output_string) => write!(f, "Log: {}", output_string),
+                LogInfo::FinalizedOutput(output_string) => write!(f, "Log: {output_string}"),
                 LogInfo::WitnessOutput(witnesses) => write!(
                     f,
                     "Log: _{}..._{}",

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use super::directives::Directive;
+use super::directives::{Directive, LogInfo};
 use crate::native_types::{Expression, Witness};
 use crate::serialisation::{read_n, read_u16, read_u32, write_bytes, write_u16, write_u32};
 use crate::BlackBoxFunc;
@@ -164,6 +164,27 @@ impl std::fmt::Display for Opcode {
                     b.last().unwrap().witness_index(),
                 )
             }
+            // Opcode::Directive(Directive::Log { output_string, witnesses }) => {
+            //     if !witnesses.is_empty() {
+            //         write!(
+            //             f,
+            //             "Log: _{}..._{}",
+            //             witnesses.first().unwrap().witness_index(),
+            //             witnesses.last().unwrap().witness_index()
+            //         )
+            //     } else {
+            //         write!(f, "Log: {}", output_string)
+            //     }
+            // }
+            Opcode::Directive(Directive::Log(info)) => match info {
+                LogInfo::FinalizedOutput(output_string) => write!(f, "Log: {}", output_string),
+                LogInfo::WitnessOutput(witnesses) => write!(
+                    f,
+                    "Log: _{}..._{}",
+                    witnesses.first().unwrap().witness_index(),
+                    witnesses.last().unwrap().witness_index()
+                ),
+            },
         }
     }
 }

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -211,10 +211,7 @@ pub fn default_is_blackbox_supported(
     // attempt to transform into supported gates. If these are also not available
     // then a compiler error will be emitted.
     fn plonk_is_supported(opcode: &BlackBoxFunc) -> bool {
-        match opcode {
-            BlackBoxFunc::AES => false,
-            _ => true,
-        }
+        !matches!(opcode, BlackBoxFunc::AES)
     }
 
     match language {

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -133,20 +133,20 @@ pub fn solve_directives(
 
             // If multiple witnesses are to be fetched for a log directive,
             // it assumed that an array is meant to be printed to standard output
-            let mut output_witnesses_string = "".to_owned();
-            output_witnesses_string.push('[');
-            let mut iter = witnesses.iter().peekable();
-
-            while let Some(w) = iter.next() {
-                let element = witness_to_value(initial_witness, *w)?;
-                if iter.peek().is_none() {
-                    output_witnesses_string.push_str(&element.to_hex());
-                } else {
-                    output_witnesses_string.push_str(&format!("{}, ", element.to_hex()));
-                }
+            //
+            // Collect all field element values corresponding to the given witness indices
+            // and convert them to hex strings.
+            let mut elements_as_hex = Vec::with_capacity(witnesses.len());
+            for witness in witnesses {
+                let element = witness_to_value(initial_witness, *witness)?;
+                elements_as_hex.push(element.to_hex());
             }
 
-            output_witnesses_string.push(']');
+            // Join all of the hex strings using a comma
+            let comma_separated_elements = elements_as_hex.join(",");
+
+            let output_witnesses_string = "[".to_owned() + &comma_separated_elements + "]";
+
             println!("{output_witnesses_string}");
 
             Ok(())

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -126,9 +126,9 @@ pub fn solve_directives(
             if witnesses.len() == 1 {
                 let witness = &witnesses[0];
 
-                let e = initial_witness
-                    .get(witness)
-                    .expect("log entry does must have a witness");
+                let e = initial_witness.get(witness).expect(
+                    "infallible: initial witness should contain the given witness index {witness}",
+                );
 
                 println!("{}", e.to_hex());
 

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -125,12 +125,8 @@ pub fn solve_directives(
 
             if witnesses.len() == 1 {
                 let witness = &witnesses[0];
-
-                let e = initial_witness.get(witness).expect(
-                    "infallible: initial witness should contain the given witness index {witness}",
-                );
-
-                println!("{}", e.to_hex());
+                let log_value = witness_to_value(initial_witness, *witness)?;
+                println!("{}", log_value.to_hex());
 
                 return Ok(());
             }

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -124,14 +124,14 @@ pub fn solve_directives(
             };
 
             if witnesses.len() == 1 {
-                match initial_witness.entry(witnesses[0]) {
-                    std::collections::btree_map::Entry::Vacant(_) => {
-                        unreachable!("log entry does must have a witness");
-                    }
-                    std::collections::btree_map::Entry::Occupied(e) => {
-                        println!("{}", e.get().to_hex());
-                    }
-                }
+                let witness = &witnesses[0];
+
+                let e = initial_witness
+                    .get(witness)
+                    .expect("log entry does must have a witness");
+
+                println!("{}", e.to_hex());
+
                 return Ok(());
             }
 

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -136,19 +136,13 @@ pub fn solve_directives(
             let mut output_witnesses_string = "".to_owned();
             output_witnesses_string.push('[');
             let mut iter = witnesses.iter().peekable();
+
             while let Some(w) = iter.next() {
-                let elem = match initial_witness.entry(*w) {
-                    std::collections::btree_map::Entry::Vacant(_) => {
-                        return Err(OpcodeResolutionError::OpcodeNotSolvable(
-                            OpcodeNotSolvable::MissingAssignment(w.0),
-                        ))
-                    }
-                    std::collections::btree_map::Entry::Occupied(e) => *e.get(),
-                };
+                let element = witness_to_value(initial_witness, *w)?;
                 if iter.peek().is_none() {
-                    output_witnesses_string.push_str(&elem.to_hex());
+                    output_witnesses_string.push_str(&element.to_hex());
                 } else {
-                    output_witnesses_string.push_str(&format!("{}, ", elem.to_hex()));
+                    output_witnesses_string.push_str(&format!("{}, ", element.to_hex()));
                 }
             }
 

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -8,7 +8,7 @@ use acir::{
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 
-use crate::{OpcodeNotSolvable, OpcodeResolutionError};
+use crate::OpcodeResolutionError;
 
 use super::{get_value, witness_to_value};
 

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -8,7 +8,7 @@ use acir::{
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 
-use crate::OpcodeResolutionError;
+use crate::{OpcodeNotSolvable, OpcodeResolutionError};
 
 use super::{get_value, witness_to_value};
 
@@ -136,8 +136,9 @@ pub fn solve_directives(
                         while let Some(w) = iter.next() {
                             let elem = match initial_witness.entry(*w) {
                                 std::collections::btree_map::Entry::Vacant(_) => {
-                                    // TODO switch this to an error
-                                    unreachable!("log entry does must have a witness");
+                                    return Err(OpcodeResolutionError::OpcodeNotSolvable(
+                                        OpcodeNotSolvable::MissingAssignment(w.0),
+                                    ))
                                 }
                                 std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
                             };

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -116,7 +116,7 @@ pub fn solve_directives(
         }
         Directive::Log(info) => {
             match info {
-                LogInfo::FinalizedOutput(output_string) => println!("{}", output_string),
+                LogInfo::FinalizedOutput(output_string) => println!("{output_string}"),
                 LogInfo::WitnessOutput(witnesses) => {
                     if witnesses.len() == 1 {
                         match initial_witness.entry(witnesses[0]) {
@@ -131,7 +131,7 @@ pub fn solve_directives(
                         // If multiple witnesses are to be fetched for a log directive,
                         // it assumed that an array is meant to be printed to standard output
                         let mut output_witnesses_string = "".to_owned();
-                        output_witnesses_string.push_str("[");
+                        output_witnesses_string.push('[');
                         let mut iter = witnesses.iter().peekable();
                         while let Some(w) = iter.next() {
                             let elem = match initial_witness.entry(*w) {
@@ -140,16 +140,16 @@ pub fn solve_directives(
                                         OpcodeNotSolvable::MissingAssignment(w.0),
                                     ))
                                 }
-                                std::collections::btree_map::Entry::Occupied(e) => e.get().clone(),
+                                std::collections::btree_map::Entry::Occupied(e) => *e.get(),
                             };
                             if iter.peek().is_none() {
-                                output_witnesses_string.push_str(&format!("{}", elem.to_hex()));
+                                output_witnesses_string.push_str(&elem.to_hex());
                             } else {
                                 output_witnesses_string.push_str(&format!("{}, ", elem.to_hex()));
                             }
                         }
-                        output_witnesses_string.push_str("]");
-                        println!("{}", output_witnesses_string);
+                        output_witnesses_string.push(']');
+                        println!("{output_witnesses_string}");
                     }
                 }
             }


### PR DESCRIPTION
# Related issue(s)

Resolves log statement issue in noir-lang repo: https://github.com/noir-lang/noir/issues/383

# Description

This includes a Log directive and the logic in the PWG for solving it.

## Summary of changes

I added a Log directive that takes a LogInfo enum. This enum can either be finalized string output or a vector of witnesses whose data has to be fetched when solving the circuit. I then added the logic for printing single values and arrays in the PWG. This logic follows similar logic from acir gen when we can construct a finalized output string.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
