### PR TITLE
feat: Update Arkworks' dependencies on `acir_field`

### DIFF
--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -10,13 +10,14 @@ description = "The field implementation being used by ACIR."
 [dependencies]
 hex = "0.4.2"
 
-ark-bn254 = { version = "^0.3.0", optional = true, default-features = false, features = [
+ark-bn254 = { version = "^0.4.0", optional = true, default-features = false, features = [
     "curve",
 ] }
-ark-bls12-381 = { version = "^0.3.0", optional = true, default-features = false, features = [
+ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false, features = [
     "curve",
 ] }
-ark-ff = { version = "^0.3.0", optional = true, default-features = false }
+ark-ff = { version = "^0.4.0", optional = true, default-features = false }
+ark-serialize = { version = "^0.4.0", default-features = false }
 
 blake2 = "0.9.1"
 cfg-if = "1.0.0"
@@ -26,7 +27,7 @@ num-bigint = "0.4"
 num-traits = "0.2.8"
 
 [dev-dependencies]
-ark-bn254 = { version = "^0.3.0", features = ["curve"] }
+ark-bn254 = { version = "^0.4.0", features = ["curve"] }
 
 [features]
 default = ["bn254"]

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -26,9 +26,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 num-bigint = "0.4"
 num-traits = "0.2.8"
 
-[dev-dependencies]
-ark-bn254 = { version = "^0.4.0", features = ["curve"] }
-
 [features]
 default = ["bn254"]
 bn254 = ["ark-bn254", "ark-ff"]

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -1,7 +1,6 @@
-use ark_ff::to_bytes;
-use ark_ff::FpParameters;
 use ark_ff::PrimeField;
 use ark_ff::Zero;
+use ark_serialize::CanonicalSerialize;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 
@@ -243,7 +242,8 @@ impl<F: PrimeField> FieldElement<F> {
     }
 
     pub fn to_hex(self) -> String {
-        let mut bytes = to_bytes!(self.0).unwrap();
+        let mut bytes = Vec::new();
+        self.0.serialize_uncompressed(&mut bytes).unwrap();
         bytes.reverse();
         hex::encode(bytes)
     }
@@ -257,7 +257,8 @@ impl<F: PrimeField> FieldElement<F> {
         // to_be_bytes! uses little endian which is why we reverse the output
         // TODO: Add a little endian equivalent, so the caller can use whichever one
         // TODO they desire
-        let mut bytes = to_bytes!(self.0).unwrap();
+        let mut bytes = Vec::new();
+        self.0.serialize_uncompressed(&mut bytes).unwrap();
         bytes.reverse();
         bytes
     }

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -1,6 +1,5 @@
 use ark_ff::PrimeField;
 use ark_ff::Zero;
-use ark_serialize::CanonicalSerialize;
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -165,7 +165,7 @@ impl<F: PrimeField> FieldElement<F> {
     /// But the representation uses 256 bits, so the top two bits are always zero
     /// This method would return 254
     pub const fn max_num_bits() -> u32 {
-        F::Params::MODULUS_BITS
+        F::MODULUS_BIT_SIZE
     }
 
     /// Maximum numbers of bytes needed to represent a field element
@@ -182,7 +182,7 @@ impl<F: PrimeField> FieldElement<F> {
     }
 
     pub fn modulus() -> BigUint {
-        F::Params::MODULUS.into()
+        F::MODULUS.into()
     }
     /// Returns None, if the string is not a canonical
     /// representation of a field element; less than the order

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -156,7 +156,7 @@ impl<F: PrimeField> FieldElement<F> {
     }
 
     pub fn pow(&self, exponent: &Self) -> Self {
-        FieldElement(self.0.pow(exponent.0.into_repr()))
+        FieldElement(self.0.pow(exponent.0.into_bigint()))
     }
 
     /// Maximum number of bits needed to represent a field element


### PR DESCRIPTION
# Related issue(s)

Resolves #68 

# Description

## Summary of changes

Update Arkworks' dependencies on `acir_field`'s `Cargo.toml`.

## Dependency additions / changes

- Update `ark-bn254` from `0.3.0` to `0.4.0`.
- Update `ark-bls12-381` from `0.3.0` to `0.4.0`.
- Update `ark-ff` from `0.3.0` to `0.4.0`.
- Add `ark-serialize 0.4.0`.
- Remove `ark-bn254` from dev-dependencies.

## Test additions / changes

-

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

The additional context was provided in #68 
