### PR TITLE
feat: Preprocess methods for ACVM interface 

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -183,7 +183,6 @@ pub trait ProofSystemCompiler {
         proof: &[u8],
         public_inputs: Vec<FieldElement>,
         circuit: Circuit,
-        proving_key: Vec<u8>,
         verification_key: Vec<u8>,
     ) -> bool;
 }

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -175,6 +175,7 @@ pub trait ProofSystemCompiler {
         &self,
         circuit: Circuit,
         witness_values: BTreeMap<Witness, FieldElement>,
+        proving_key: Vec<u8>,
     ) -> Vec<u8>;
 
     fn verify_with_vk(
@@ -182,6 +183,7 @@ pub trait ProofSystemCompiler {
         proof: &[u8],
         public_inputs: Vec<FieldElement>,
         circuit: Circuit,
+        verification_key: Vec<u8>,
     ) -> bool;
 }
 

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -169,7 +169,7 @@ pub trait ProofSystemCompiler {
 
     fn get_exact_circuit_size(&self, circuit: Circuit) -> u32;
 
-    fn preprocess(&self, circuit: Circuit);
+    fn preprocess(&self, circuit: Circuit) -> (Vec<u8>, Vec<u8>);
 
     fn prove_with_pk(
         &self,

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -183,6 +183,7 @@ pub trait ProofSystemCompiler {
         proof: &[u8],
         public_inputs: Vec<FieldElement>,
         circuit: Circuit,
+        proving_key: Vec<u8>,
         verification_key: Vec<u8>,
     ) -> bool;
 }

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -168,6 +168,21 @@ pub trait ProofSystemCompiler {
     ) -> bool;
 
     fn get_exact_circuit_size(&self, circuit: Circuit) -> u32;
+
+    fn preprocess(&self, circuit: Circuit);
+
+    fn prove_with_pk(
+        &self,
+        circuit: Circuit,
+        witness_values: BTreeMap<Witness, FieldElement>,
+    ) -> Vec<u8>;
+
+    fn verify_with_vk(
+        &self,
+        proof: &[u8],
+        public_inputs: Vec<FieldElement>,
+        circuit: Circuit,
+    ) -> bool;
 }
 
 /// Supported NP complete languages


### PR DESCRIPTION
# Related issue(s)

Resolves #64 #65 #46 

# Description

Add ACVM methods for preprocessing and proof creation from proving and verification keys 

## Summary of changes

This PR simply adds methods to the `ProofSystemCompiler` trait for both preprocessing (proving and verification key generation) as well as new methods to create proofs with a proving key and to verify those proofs with a verification key. 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

These methods are tested by fully integrating with a given backend. Currently this is only being tested with the `aztec_backend`. After the `aztec_backend` is fully working I will also change the `marlin_arkworks_backend` to reflect the new acvm. We should wait on merging this PR until the backends are fully working with the respective changes.  

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
