### PR TITLE
chore: expose acir_field through acir

### DIFF
--- a/acir/Cargo.toml
+++ b/acir/Cargo.toml
@@ -18,3 +18,7 @@ flate2 = "1.0.24"
 serde_json = "1.0"
 strum = "0.24"
 strum_macros = "0.24"
+
+[features]
+bn254 = ["acir_field/bn254"]
+bls12_381 = ["acir_field/bls12_381"]

--- a/acir/src/lib.rs
+++ b/acir/src/lib.rs
@@ -4,5 +4,6 @@ pub mod circuit;
 pub mod native_types;
 mod serialization;
 
+pub use acir_field;
 pub use acir_field::FieldElement;
 pub use circuit::black_box_functions::BlackBoxFunc;

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -11,7 +11,6 @@ description = "The virtual machine that processes ACIR given a backend/proof sys
 num-bigint = "0.4"
 num-traits = "0.2"
 acir = { version = "0.3.1", path = "../acir" }
-acir_field = { version = "0.3.1", path = "../acir_field", default-features = false }
 stdlib = { package = "acvm_stdlib", version = "0.3.0", path = "../stdlib" }
 
 sha2 = "0.9.3"
@@ -28,8 +27,8 @@ indexmap = "1.7.0"
 thiserror = "1.0.21"
 
 [features]
-bn254 = ["acir_field/bn254"]
-bls12_381 = ["acir_field/bls12_381"]
+bn254 = ["acir/bn254"]
+bls12_381 = ["acir/bls12_381"]
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -7,5 +7,4 @@ description = "The ACVM standard library."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acir = { version = "0.3.1", path = "../acir" }
-acir_field = { version = "0.3.1", path = "../acir_field", default-features = true }
+acir = { version = "0.3.1", path = "../acir", features = ["bn254"] }

--- a/stdlib/src/fallback.rs
+++ b/stdlib/src/fallback.rs
@@ -1,9 +1,9 @@
 use crate::helpers::VariableStore;
 use acir::{
+    acir_field::FieldElement,
     circuit::{directives::Directive, Opcode},
     native_types::{Expression, Witness},
 };
-use acir_field::FieldElement;
 
 // Perform bit decomposition on the provided expression
 #[deprecated(note = "use bit_decomposition function instead")]


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves https://github.com/noir-lang/acvm/issues/51

# Description

expose acir_field through acir

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

1. add `acir` to have two features that references features in `acir_field`
2. change `acvm` features to reference feaures of `acir`
3. delete `acir_field` dependencies in `acvm` and `stdlib`

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
