### PR TITLE
chore(acvm): rename remaining references to gadget calls

### DIFF
--- a/acvm/src/compiler/fallback.rs
+++ b/acvm/src/compiler/fallback.rs
@@ -51,12 +51,13 @@ pub fn fallback(acir: Circuit, is_supported: IsBlackBoxSupported) -> Result<Circ
 }
 
 fn opcode_fallback(
-    gc: &BlackBoxFuncCall,
+    bb_func_call: &BlackBoxFuncCall,
     current_witness_idx: u32,
 ) -> Result<(u32, Vec<Opcode>), CompileError> {
-    let (updated_witness_index, opcodes_fallback) = match gc.name {
+    let (updated_witness_index, opcodes_fallback) = match bb_func_call.name {
         BlackBoxFunc::AND => {
-            let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
+            let (lhs, rhs, result, num_bits) =
+                crate::pwg::logic::extract_input_output(bb_func_call);
             stdlib::fallback::and(
                 Expression::from(&lhs),
                 Expression::from(&rhs),
@@ -66,7 +67,8 @@ fn opcode_fallback(
             )
         }
         BlackBoxFunc::XOR => {
-            let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
+            let (lhs, rhs, result, num_bits) =
+                crate::pwg::logic::extract_input_output(bb_func_call);
             stdlib::fallback::xor(
                 Expression::from(&lhs),
                 Expression::from(&rhs),
@@ -78,7 +80,7 @@ fn opcode_fallback(
         BlackBoxFunc::RANGE => {
             // TODO: add consistency checks in one place
             // TODO: we aren't checking that range gate should have one input
-            let input = &gc.inputs[0];
+            let input = &bb_func_call.inputs[0];
             // Note there are no outputs because range produces no outputs
             stdlib::fallback::range(
                 Expression::from(&input.witness),
@@ -87,7 +89,7 @@ fn opcode_fallback(
             )
         }
         _ => {
-            return Err(CompileError::UnsupportedBlackBox(gc.name));
+            return Err(CompileError::UnsupportedBlackBox(bb_func_call.name));
         }
     };
 

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -59,10 +59,12 @@ impl LogicSolver {
 }
 // TODO: Is there somewhere else that we can put this?
 // TODO: extraction methods are needed for some opcodes like logic and range
-pub(crate) fn extract_input_output(gc: &BlackBoxFuncCall) -> (Witness, Witness, Witness, u32) {
-    let a = &gc.inputs[0];
-    let b = &gc.inputs[1];
-    let result = &gc.outputs[0];
+pub(crate) fn extract_input_output(
+    bb_func_call: &BlackBoxFuncCall,
+) -> (Witness, Witness, Witness, u32) {
+    let a = &bb_func_call.inputs[0];
+    let b = &bb_func_call.inputs[1];
+    let result = &bb_func_call.outputs[0];
 
     // The num_bits variable should be the same for all witnesses
     assert_eq!(


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

Remaining instances of `gc` (gadget call) have been renamed to `bb_func_call`.

## Dependency additions / changes

N/A

## Test additions / changes

N/A

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
