### PR TITLE
Remove duplicated match statement for Directive::Log

### DIFF
--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -208,43 +208,6 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::Log(info) => {
-            let witnesses = match info {
-                LogInfo::FinalizedOutput(output_string) => {
-                    println!("{output_string}");
-                    return Ok(());
-                }
-                LogInfo::WitnessOutput(witnesses) => witnesses,
-            };
-
-            if witnesses.len() == 1 {
-                let witness = &witnesses[0];
-                let log_value = witness_to_value(initial_witness, *witness)?;
-                println!("{}", log_value.to_hex());
-
-                return Ok(());
-            }
-
-            // If multiple witnesses are to be fetched for a log directive,
-            // it assumed that an array is meant to be printed to standard output
-            //
-            // Collect all field element values corresponding to the given witness indices
-            // and convert them to hex strings.
-            let mut elements_as_hex = Vec::with_capacity(witnesses.len());
-            for witness in witnesses {
-                let element = witness_to_value(initial_witness, *witness)?;
-                elements_as_hex.push(element.to_hex());
-            }
-
-            // Join all of the hex strings using a comma
-            let comma_separated_elements = elements_as_hex.join(",");
-
-            let output_witnesses_string = "[".to_owned() + &comma_separated_elements + "]";
-
-            println!("{output_witnesses_string}");
-
-            Ok(())
-        }
     }
 }
 


### PR DESCRIPTION
# Related issue(s)

No issue quick fix I noticed

Resolves (link to issue)

# Description

We had an unreachable match case in `solve_directives` due to duplicated `Directive::Log` logic

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
