### PR TITLE
chore: add tests for `from_hex` and `to_hex`

### DIFF
--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -405,6 +405,28 @@ mod test {
             assert_eq!(res.to_be_bytes(), x.to_be_bytes());
         }
     }
+
+    #[test]
+    fn serialize_fixed_test_vectors() {
+        // Serialized field elements from of 0, -1, -2, -3
+        let hex_strings = vec![
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000000",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593efffffff",
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593effffffe",
+        ];
+
+        for (i, string) in hex_strings.into_iter().enumerate() {
+            let minus_i_field_element =
+                -crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(i as i128);
+            assert_eq!(minus_i_field_element.to_hex(), string)
+        }
+    }
+    #[test]
+    fn max_num_bits_smoke() {
+        let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
+        assert_eq!(max_num_bits_bn254, 254)
+    }
 }
 
 fn mask_vector_le(bytes: &mut [u8], num_bits: usize) {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description


This PR adds test for methods in acir_field, so that we can test if a new version of arkworks breaks them.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
