### PR TITLE
feat(acir)!: Add Keccak256 Opcode

### DIFF
--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -21,6 +21,7 @@ pub enum BlackBoxFunc {
     HashToField128Security,
     EcdsaSecp256k1,
     FixedBaseScalarMul,
+    Keccak256,
 }
 
 impl std::fmt::Display for BlackBoxFunc {
@@ -44,6 +45,7 @@ impl BlackBoxFunc {
             BlackBoxFunc::AND => 9,
             BlackBoxFunc::XOR => 10,
             BlackBoxFunc::RANGE => 11,
+            BlackBoxFunc::Keccak256 => 12,
         }
     }
     pub fn from_u16(index: u16) -> Option<Self> {
@@ -60,6 +62,7 @@ impl BlackBoxFunc {
             9 => BlackBoxFunc::AND,
             10 => BlackBoxFunc::XOR,
             11 => BlackBoxFunc::RANGE,
+            12 => BlackBoxFunc::Keccak256,
             _ => return None,
         };
         Some(function)
@@ -78,6 +81,7 @@ impl BlackBoxFunc {
             BlackBoxFunc::AND => "and",
             BlackBoxFunc::XOR => "xor",
             BlackBoxFunc::RANGE => "range",
+            BlackBoxFunc::Keccak256 => "keccak256",
         }
     }
     pub fn lookup(op_name: &str) -> Option<BlackBoxFunc> {
@@ -94,6 +98,7 @@ impl BlackBoxFunc {
             "and" => Some(BlackBoxFunc::AND),
             "xor" => Some(BlackBoxFunc::XOR),
             "range" => Some(BlackBoxFunc::RANGE),
+            "keccak256" => Some(BlackBoxFunc::Keccak256),
             _ => None,
         }
     }
@@ -161,6 +166,11 @@ impl BlackBoxFunc {
                 name,
                 input_size: InputSize::Fixed(1),
                 output_size: OutputSize(0),
+            },
+            BlackBoxFunc::Keccak256 => FuncDefinition {
+                name,
+                input_size: InputSize::Variable,
+                output_size: OutputSize(32),
             },
         }
     }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves #90 

# Description

Keccak256 looks exactly the same as Blake256 and Sha256 from an opcode perspective, so it was mostly just giving it an opcode number and copying the function definition from sha256

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
