### PR TITLE
feat(acvm)!: switch to accepting public inputs as a map

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -152,7 +152,7 @@ pub trait ProofSystemCompiler {
     fn verify_from_cs(
         &self,
         proof: &[u8],
-        public_inputs: BTreeMap<Witness, FieldElement>,
+        public_inputs: Vec<FieldElement>,
         circuit: Circuit,
     ) -> bool;
 

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -163,7 +163,7 @@ pub trait ProofSystemCompiler {
     fn verify_from_cs(
         &self,
         proof: &[u8],
-        public_inputs: Vec<FieldElement>,
+        public_inputs: BTreeMap<Witness, FieldElement>,
         circuit: Circuit,
     ) -> bool;
 
@@ -181,7 +181,7 @@ pub trait ProofSystemCompiler {
     fn verify_with_vk(
         &self,
         proof: &[u8],
-        public_inputs: Vec<FieldElement>,
+        public_inputs: BTreeMap<Witness, FieldElement>,
         circuit: Circuit,
         verification_key: Vec<u8>,
     ) -> bool;


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

~~`verify_from_cs` and~~ `verify_with_vk` now accept a `BTreeMap<Witness, FieldElement>`. This is used in combination with the explicit ABI->Witness map in https://github.com/noir-lang/noir/pull/851 to handle multiple ABI fields (params + return value) being mapped to the same witness index semantically.

I've reverted the change to `verify_from_cs` as we should leave it unchanged until we remove it.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
