### PR TITLE
chore: Fix small nits for ToRadix

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -31,8 +31,6 @@ pub enum OpcodeNotSolvable {
     MissingAssignment(u32),
     #[error("expression has too many unknowns {0}")]
     ExpressionHasTooManyUnknowns(Expression),
-    #[error("compiler error: unreachable code")]
-    UnreachableCode,
 }
 
 #[derive(PartialEq, Eq, Debug, Error)]

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -117,11 +117,11 @@ pub fn solve_directives(
             let zeroes = vec![0u8; padding_len];
 
             let padded_decomposed_integer: Vec<_> = if *is_little_endian {
-                // Pad the beginning with zeroes for little endian
-                zeroes.into_iter().chain(decomposed_integer).collect()
-            } else {
-                // Pad the ending with zeroes for big endian
+                // Pad the ending with zeroes for little endian
                 decomposed_integer.into_iter().chain(zeroes).collect()
+            } else {
+                // Pad the beginning with zeroes for big endian
+                zeroes.into_iter().chain(decomposed_integer).collect()
             };
 
             for (witness_index, digit) in b.iter().zip(padded_decomposed_integer) {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

This does a small refactor of the ToRadix directive. Since both little endian and big endian rely on the number of witnesses being assigned to, to be more than the number of decomposed digits, this was added for both branches.

We also now pad the decomposed integer to the beginning or end depending on its endianness.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
