### PR TITLE
fix(ci): Update dependency versions in the workspace file

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,24 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "component": "root"
+      "component": "root",
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.acir.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.acir_field.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.stdlib.version"
+        }
+      ]
     },
     "acir": {
       "component": "acir"


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

When I added release-please to the project, I missed the fact that the dependency versions were specified in the Cargo.toml workspace file. This adds updaters to ensure that the dependency versions are updated by release-please too.

I'm not sure I totally agree with specifying the local dependencies in the workspace like this but I didn't want to make that larger change just for the fix.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
