### PR TITLE
feat(ci): Publish crates upon release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      acvm-ref:
+        description: The acvm reference to checkout
+        required: true
+
+jobs:
+  publish:
+    name: Publish in order
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.acvm-ref }}
+
+      - name: Setup toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.66.0
+
+      # These steps are in a specific order so crate dependencies are updated first
+      - name: Publish acir_field
+        run: |
+          cargo publish --package acir_field
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+
+      - name: Publish acir
+        run: |
+          cargo publish --package acir
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+
+      - name: Publish acvm
+        run: |
+          cargo publish --package acvm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+
+      - name: Publish acvm_stdlib
+        run: |
+          cargo publish --package acvm_stdlib
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,16 @@ jobs:
         uses: google-github-actions/release-please-action@v3
         with:
           command: manifest
+
+  publish:
+    name: Publish crates
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.tag-name }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to publish workflow
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: publish.yml
+          ref: master
+          inputs: '{ "acvm-ref": "${{ needs.release-please.outputs.tag-name }}" }'


### PR DESCRIPTION
# Related issue(s)

Resolves #93

# Description

This adds automatic publishing to crates.io when a release-please PR is merged (after the tags are created). I separated this out into a separate workflow and dispatch to it so we can manually run the publish workflow if we need, which can be useful for recovering from a failed build, debugging, etc.

Since cargo doesn't support publishing everything in a workspace, we have to publish the exact correct order and this will need to be updated if the dependencies change.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
