### PR TITLE
feat!: Log Directive support for traces

### DIFF
--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -172,6 +172,8 @@ impl std::fmt::Display for Opcode {
                     LogOutputInfo::FinalizedOutput(output_string) => {
                         write!(f, "Log: {output_string}, log type {is_trace_display}")
                     }
+                    // Note: This assumes that the witnesses have contiguous indices.
+                    // This may not always be the case however we don't want to print out the full vec.
                     LogOutputInfo::WitnessOutput(witnesses) => write!(
                         f,
                         "Log: _{}..._{}, log type: {is_trace_display}",

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Write};
 
-use super::directives::{Directive, LogInfo};
+use super::directives::{Directive, LogOutputInfo};
 use crate::native_types::{Expression, Witness};
 use crate::serialization::{read_n, read_u16, read_u32, write_bytes, write_u16, write_u32};
 use crate::BlackBoxFunc;
@@ -188,15 +188,23 @@ impl std::fmt::Display for Opcode {
                     bits.last().unwrap().witness_index(),
                 )
             }
-            Opcode::Directive(Directive::Log(info)) => match info {
-                LogInfo::FinalizedOutput(output_string) => write!(f, "Log: {output_string}"),
-                LogInfo::WitnessOutput(witnesses) => write!(
-                    f,
-                    "Log: _{}..._{}",
-                    witnesses.first().unwrap().witness_index(),
-                    witnesses.last().unwrap().witness_index()
-                ),
-            },
+            Opcode::Directive(Directive::Log {
+                is_trace,
+                output_info,
+            }) => {
+                let is_trace_display = if *is_trace { "trace" } else { "println" };
+                match output_info {
+                    LogOutputInfo::FinalizedOutput(output_string) => {
+                        write!(f, "Log: {output_string}, log type {is_trace_display}")
+                    }
+                    LogOutputInfo::WitnessOutput(witnesses) => write!(
+                        f,
+                        "Log: _{}..._{}, log type: {is_trace_display}",
+                        witnesses.first().unwrap().witness_index(),
+                        witnesses.last().unwrap().witness_index(),
+                    ),
+                }
+            }
         }
     }
 }

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -197,8 +197,6 @@ pub fn solve_directives(
             };
 
             if witnesses.len() == 1 {
-                dbg!(witnesses.clone());
-
                 let witness = &witnesses[0];
                 let log_value = witness_to_value(initial_witness, *witness)?;
 


### PR DESCRIPTION
…from printing when solving directives

# Related issue(s)

Resolves #95 

# Description

`Directive::Log` no longer prints the evaluated log while it is being evaluating during partial witness generation. This enables us to have both trace functionality and move logic for displaying logs to the code that calls the PWG rather than keeping it with solver itself.

## Summary of changes

`solve` under the PWG now takes in a vector of directives. These directives are limited to be `Directive::Log` as it does not make sense to be returning any other directive. The log directive that is returned must have have finalized output or else that means there is a critical bug. 

Several more changes showing how to handle logs correctly will be supplied in `nargo`. 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
