### PR TITLE
chore!: make BlackBoxFunc non-exhaustive

### DIFF
--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(test)]
 use strum_macros::EnumIter;
 
+#[non_exhaustive]
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Clone, Debug, Hash, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(test, derive(EnumIter))]


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

Currently adding a new black box function is a breaking change for all backends. For instance in this function we explicitly enumerate all the bb funcs which we do and don't support.

https://github.com/noir-lang/aztec_backend/blob/cff757dca7971161e4bd25e7a744d910c37c22be/barretenberg_static_lib/src/acvm_interop/proof_system.rs#L61-L76

If we were to add a new black box function, rather than defaulting to not supporting it and falling back to arithmetic gates, `aztec_backend` will fail to compile.

This PR changes `enum BlackBoxFunc` to be non-exhaustive so backends must explicitly handle any unknown black box functions when matching on them. This should held reduce the amount of breaking changes related to adding new bb functions going forwards.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
