### PR TITLE
Copy .rustfmt.toml from noir repo

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+use_small_heuristics = "Max"

--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -119,16 +119,12 @@ impl BlackBoxFunc {
                 input_size: InputSize::Variable,
                 output_size: OutputSize(32),
             },
-            BlackBoxFunc::HashToField128Security => FuncDefinition {
-                name,
-                input_size: InputSize::Variable,
-                output_size: OutputSize(1),
-            },
-            BlackBoxFunc::MerkleMembership => FuncDefinition {
-                name,
-                input_size: InputSize::Variable,
-                output_size: OutputSize(1),
-            },
+            BlackBoxFunc::HashToField128Security => {
+                FuncDefinition { name, input_size: InputSize::Variable, output_size: OutputSize(1) }
+            }
+            BlackBoxFunc::MerkleMembership => {
+                FuncDefinition { name, input_size: InputSize::Variable, output_size: OutputSize(1) }
+            }
             BlackBoxFunc::SchnorrVerify => FuncDefinition {
                 name,
                 // XXX: input_size can be changed to fixed, once we hash
@@ -137,36 +133,24 @@ impl BlackBoxFunc {
                 input_size: InputSize::Variable,
                 output_size: OutputSize(1),
             },
-            BlackBoxFunc::Pedersen => FuncDefinition {
-                name,
-                input_size: InputSize::Variable,
-                output_size: OutputSize(2),
-            },
-            BlackBoxFunc::EcdsaSecp256k1 => FuncDefinition {
-                name,
-                input_size: InputSize::Variable,
-                output_size: OutputSize(1),
-            },
-            BlackBoxFunc::FixedBaseScalarMul => FuncDefinition {
-                name,
-                input_size: InputSize::Fixed(1),
-                output_size: OutputSize(2),
-            },
-            BlackBoxFunc::AND => FuncDefinition {
-                name,
-                input_size: InputSize::Fixed(2),
-                output_size: OutputSize(1),
-            },
-            BlackBoxFunc::XOR => FuncDefinition {
-                name,
-                input_size: InputSize::Fixed(2),
-                output_size: OutputSize(1),
-            },
-            BlackBoxFunc::RANGE => FuncDefinition {
-                name,
-                input_size: InputSize::Fixed(1),
-                output_size: OutputSize(0),
-            },
+            BlackBoxFunc::Pedersen => {
+                FuncDefinition { name, input_size: InputSize::Variable, output_size: OutputSize(2) }
+            }
+            BlackBoxFunc::EcdsaSecp256k1 => {
+                FuncDefinition { name, input_size: InputSize::Variable, output_size: OutputSize(1) }
+            }
+            BlackBoxFunc::FixedBaseScalarMul => {
+                FuncDefinition { name, input_size: InputSize::Fixed(1), output_size: OutputSize(2) }
+            }
+            BlackBoxFunc::AND => {
+                FuncDefinition { name, input_size: InputSize::Fixed(2), output_size: OutputSize(1) }
+            }
+            BlackBoxFunc::XOR => {
+                FuncDefinition { name, input_size: InputSize::Fixed(2), output_size: OutputSize(1) }
+            }
+            BlackBoxFunc::RANGE => {
+                FuncDefinition { name, input_size: InputSize::Fixed(1), output_size: OutputSize(0) }
+            }
             BlackBoxFunc::Keccak256 => FuncDefinition {
                 name,
                 input_size: InputSize::Variable,
@@ -217,10 +201,7 @@ mod test {
     fn consistent_function_names() {
         for bb_func in BlackBoxFunc::iter() {
             let resolved_func = BlackBoxFunc::lookup(bb_func.name()).unwrap_or_else(|| {
-                panic!(
-                    "BlackBoxFunc::lookup couldn't find black box function {}",
-                    bb_func
-                )
+                panic!("BlackBoxFunc::lookup couldn't find black box function {}", bb_func)
             });
             assert_eq!(
                 resolved_func, bb_func,
@@ -234,10 +215,7 @@ mod test {
             let func_index = bb_func.to_u16();
             let got_bb_func =
                 BlackBoxFunc::from_u16(func_index).expect("blackbox function should have an index");
-            assert_eq!(
-                got_bb_func, bb_func,
-                "BlackBox function index lookup is inconsistent"
-            )
+            assert_eq!(got_bb_func, bb_func, "BlackBox function index lookup is inconsistent")
         }
     }
 }

--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -92,13 +92,7 @@ impl Directive {
                 write_u32(&mut writer, x.witness_index())?;
                 write_u32(&mut writer, result.witness_index())?;
             }
-            Directive::Quotient {
-                a,
-                b,
-                q,
-                r,
-                predicate,
-            } => {
+            Directive::Quotient { a, b, q, r, predicate } => {
                 a.write(&mut writer)?;
                 b.write(&mut writer)?;
                 write_u32(&mut writer, q.witness_index())?;
@@ -123,12 +117,7 @@ impl Directive {
                 write_u32(&mut writer, r.witness_index())?;
                 write_u32(&mut writer, *bit_size)?;
             }
-            Directive::ToRadix {
-                a,
-                b,
-                radix,
-                is_little_endian,
-            } => {
+            Directive::ToRadix { a, b, radix, is_little_endian } => {
                 a.write(&mut writer)?;
                 write_u32(&mut writer, b.len() as u32)?;
                 for bit in b {
@@ -137,12 +126,7 @@ impl Directive {
                 write_u32(&mut writer, *radix)?;
                 write_u32(&mut writer, *is_little_endian as u32)?;
             }
-            Directive::PermutationSort {
-                inputs: a,
-                tuple,
-                bits,
-                sort_by,
-            } => {
+            Directive::PermutationSort { inputs: a, tuple, bits, sort_by } => {
                 write_u32(&mut writer, *tuple)?;
                 write_u32(&mut writer, a.len() as u32)?;
                 for e in a {
@@ -197,13 +181,7 @@ impl Directive {
                     false => None,
                 };
 
-                Ok(Directive::Quotient {
-                    a,
-                    b,
-                    q,
-                    r,
-                    predicate,
-                })
+                Ok(Directive::Quotient { a, b, q, r, predicate })
             }
             2 => {
                 let a = Expression::read(&mut reader)?;
@@ -231,12 +209,7 @@ impl Directive {
                 let radix = read_u32(&mut reader)?;
                 let is_little_endian = read_u32(&mut reader)?;
 
-                Ok(Directive::ToRadix {
-                    a,
-                    b,
-                    radix,
-                    is_little_endian: is_little_endian == 1,
-                })
+                Ok(Directive::ToRadix { a, b, radix, is_little_endian: is_little_endian == 1 })
             }
             6 => {
                 let tuple = read_u32(&mut reader)?;
@@ -260,12 +233,7 @@ impl Directive {
                 for _ in 0..sort_by_len {
                     sort_by.push(read_u32(&mut reader)?);
                 }
-                Ok(Directive::PermutationSort {
-                    inputs: a,
-                    tuple,
-                    bits,
-                    sort_by,
-                })
+                Ok(Directive::PermutationSort { inputs: a, tuple, bits, sort_by })
             }
 
             _ => Err(std::io::ErrorKind::InvalidData.into()),
@@ -293,10 +261,7 @@ fn serialization_roundtrip() {
         (directive, got_dir)
     }
     // TODO: Find a way to ensure that we include all of the variants
-    let invert = Directive::Invert {
-        x: Witness(10),
-        result: Witness(10),
-    };
+    let invert = Directive::Invert { x: Witness(10), result: Witness(10) };
 
     let quotient_none = Directive::Quotient {
         a: Expression::default(),
@@ -320,12 +285,8 @@ fn serialization_roundtrip() {
         bit_size: 123,
     };
 
-    let odd_range = Directive::OddRange {
-        a: Witness(1u32),
-        b: Witness(2u32),
-        r: Witness(3u32),
-        bit_size: 32,
-    };
+    let odd_range =
+        Directive::OddRange { a: Witness(1u32), b: Witness(2u32), r: Witness(3u32), bit_size: 32 };
 
     let to_radix_le = Directive::ToRadix {
         a: Expression::default(),

--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -94,11 +94,7 @@ impl Circuit {
             opcodes.push(opcode)
         }
 
-        Ok(Self {
-            current_witness_index,
-            opcodes,
-            public_inputs,
-        })
+        Ok(Self { current_witness_index, opcodes, public_inputs })
     }
 }
 
@@ -133,10 +129,7 @@ pub struct PublicInputs(pub BTreeSet<Witness>);
 impl PublicInputs {
     /// Returns the witness index of each public input
     pub fn indices(&self) -> Vec<u32> {
-        self.0
-            .iter()
-            .map(|witness| witness.witness_index())
-            .collect()
+        self.0.iter().map(|witness| witness.witness_index()).collect()
     }
 
     pub fn contains(&self, index: usize) -> bool {
@@ -159,14 +152,8 @@ mod test {
         Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
             name: crate::BlackBoxFunc::AND,
             inputs: vec![
-                FunctionInput {
-                    witness: Witness(1),
-                    num_bits: 4,
-                },
-                FunctionInput {
-                    witness: Witness(2),
-                    num_bits: 4,
-                },
+                FunctionInput { witness: Witness(1), num_bits: 4 },
+                FunctionInput { witness: Witness(2), num_bits: 4 },
             ],
             outputs: vec![Witness(3)],
         })
@@ -174,10 +161,7 @@ mod test {
     fn range_opcode() -> Opcode {
         Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
             name: crate::BlackBoxFunc::RANGE,
-            inputs: vec![FunctionInput {
-                witness: Witness(1),
-                num_bits: 8,
-            }],
+            inputs: vec![FunctionInput { witness: Witness(1), num_bits: 8 }],
             outputs: vec![],
         })
     }

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -85,13 +85,7 @@ impl std::fmt::Display for Opcode {
             Opcode::Arithmetic(expr) => {
                 write!(f, "EXPR [ ")?;
                 for i in &expr.mul_terms {
-                    write!(
-                        f,
-                        "({}, _{}, _{}) ",
-                        i.0,
-                        i.1.witness_index(),
-                        i.2.witness_index()
-                    )?;
+                    write!(f, "({}, _{}, _{}) ", i.0, i.1.witness_index(), i.2.witness_index())?;
                 }
                 for i in &expr.linear_combinations {
                     write!(f, "({}, _{}) ", i.0, i.1.witness_index())?;
@@ -118,13 +112,7 @@ impl std::fmt::Display for Opcode {
                     bit_size
                 )
             }
-            Opcode::Directive(Directive::Quotient {
-                a,
-                b,
-                q,
-                r,
-                predicate,
-            }) => {
+            Opcode::Directive(Directive::Quotient { a, b, q, r, predicate }) => {
                 write!(f, "DIR::QUOTIENT ")?;
                 if let Some(pred) = predicate {
                     writeln!(f, "PREDICATE = {pred}")?;
@@ -152,12 +140,7 @@ impl std::fmt::Display for Opcode {
                 )
             }
             Opcode::BlackBoxFuncCall(g) => write!(f, "{g}"),
-            Opcode::Directive(Directive::ToRadix {
-                a,
-                b,
-                radix: _,
-                is_little_endian,
-            }) => {
+            Opcode::Directive(Directive::ToRadix { a, b, radix: _, is_little_endian }) => {
                 write!(f, "DIR::TORADIX ")?;
                 write!(
                     f,
@@ -170,12 +153,7 @@ impl std::fmt::Display for Opcode {
                     if *is_little_endian { "little" } else { "big" }
                 )
             }
-            Opcode::Directive(Directive::PermutationSort {
-                inputs: a,
-                tuple,
-                bits,
-                sort_by,
-            }) => {
+            Opcode::Directive(Directive::PermutationSort { inputs: a, tuple, bits, sort_by }) => {
                 write!(f, "DIR::PERMUTATIONSORT ")?;
                 write!(
                     f,
@@ -263,11 +241,7 @@ impl BlackBoxFuncCall {
             outputs.push(witness)
         }
 
-        Ok(BlackBoxFuncCall {
-            name,
-            inputs,
-            outputs,
-        })
+        Ok(BlackBoxFuncCall { name, inputs, outputs })
     }
 }
 
@@ -291,11 +265,8 @@ impl std::fmt::Display for BlackBoxFuncCall {
         let inputs_str = if should_abbreviate_inputs {
             let mut result = String::new();
             for (index, inp) in self.inputs.iter().enumerate() {
-                result += &format!(
-                    "(_{}, num_bits: {})",
-                    inp.witness.witness_index(),
-                    inp.num_bits
-                );
+                result +=
+                    &format!("(_{}, num_bits: {})", inp.witness.witness_index(), inp.num_bits);
                 // Add a comma, unless it is the last entry
                 if index != self.inputs.len() - 1 {
                     result += ", "
@@ -372,22 +343,14 @@ fn serialization_roundtrip() {
     let opcode_black_box_func = Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
         name: BlackBoxFunc::AES,
         inputs: vec![
-            FunctionInput {
-                witness: Witness(1u32),
-                num_bits: 12,
-            },
-            FunctionInput {
-                witness: Witness(24u32),
-                num_bits: 32,
-            },
+            FunctionInput { witness: Witness(1u32), num_bits: 12 },
+            FunctionInput { witness: Witness(24u32), num_bits: 32 },
         ],
         outputs: vec![Witness(123u32), Witness(245u32)],
     });
 
-    let opcode_directive = Opcode::Directive(Directive::Invert {
-        x: Witness(1234u32),
-        result: Witness(56789u32),
-    });
+    let opcode_directive =
+        Opcode::Directive(Directive::Invert { x: Witness(1234u32), result: Witness(56789u32) });
 
     let opcodes = vec![opcode_arith, opcode_black_box_func, opcode_directive];
 

--- a/acir/src/native_types/arithmetic.rs
+++ b/acir/src/native_types/arithmetic.rs
@@ -44,11 +44,7 @@ impl std::fmt::Display for Expression {
         if self.mul_terms.is_empty() && self.linear_combinations.len() == 1 && self.q_c.is_zero() {
             write!(f, "x{}", self.linear_combinations[0].1.witness_index())
         } else {
-            write!(
-                f,
-                "%{:?}%",
-                crate::circuit::opcodes::Opcode::Arithmetic(self.clone())
-            )
+            write!(f, "%{:?}%", crate::circuit::opcodes::Opcode::Arithmetic(self.clone()))
         }
     }
 }
@@ -93,10 +89,7 @@ impl Expression {
     }
 
     pub fn from_field(q_c: FieldElement) -> Expression {
-        Self {
-            q_c,
-            ..Default::default()
-        }
+        Self { q_c, ..Default::default() }
     }
 
     pub fn one() -> Expression {
@@ -241,8 +234,7 @@ impl Expression {
     /// Sorts gate in a deterministic order
     /// XXX: We can probably make this more efficient by sorting on each phase. We only care if it is deterministic
     pub fn sort(&mut self) {
-        self.mul_terms
-            .sort_by(|a, b| a.1.cmp(&b.1).then(a.2.cmp(&b.2)));
+        self.mul_terms.sort_by(|a, b| a.1.cmp(&b.1).then(a.2.cmp(&b.2)));
         self.linear_combinations.sort_by(|a, b| a.1.cmp(&b.1));
     }
 }
@@ -251,27 +243,17 @@ impl Mul<&FieldElement> for &Expression {
     type Output = Expression;
     fn mul(self, rhs: &FieldElement) -> Self::Output {
         // Scale the mul terms
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .map(|(q_m, w_l, w_r)| (*q_m * *rhs, *w_l, *w_r))
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (*q_m * *rhs, *w_l, *w_r)).collect();
 
         // Scale the linear combinations terms
-        let lin_combinations: Vec<_> = self
-            .linear_combinations
-            .iter()
-            .map(|(q_l, w_l)| (*q_l * *rhs, *w_l))
-            .collect();
+        let lin_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_l, w_l)| (*q_l * *rhs, *w_l)).collect();
 
         // Scale the constant
         let q_c = self.q_c * *rhs;
 
-        Expression {
-            mul_terms,
-            q_c,
-            linear_combinations: lin_combinations,
-        }
+        Expression { mul_terms, q_c, linear_combinations: lin_combinations }
     }
 }
 impl Add<&FieldElement> for Expression {
@@ -280,11 +262,7 @@ impl Add<&FieldElement> for Expression {
         // Increase the constant
         let q_c = self.q_c + *rhs;
 
-        Expression {
-            mul_terms: self.mul_terms,
-            q_c,
-            linear_combinations: self.linear_combinations,
-        }
+        Expression { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
     }
 }
 impl Sub<&FieldElement> for Expression {
@@ -293,11 +271,7 @@ impl Sub<&FieldElement> for Expression {
         // Increase the constant
         let q_c = self.q_c - *rhs;
 
-        Expression {
-            mul_terms: self.mul_terms,
-            q_c,
-            linear_combinations: self.linear_combinations,
-        }
+        Expression { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
     }
 }
 
@@ -306,12 +280,8 @@ impl Add<&Expression> for &Expression {
     fn add(self, rhs: &Expression) -> Expression {
         // XXX(med) : Implement an efficient way to do this
 
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .cloned()
-            .chain(rhs.mul_terms.iter().cloned())
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().cloned().chain(rhs.mul_terms.iter().cloned()).collect();
 
         let linear_combinations: Vec<_> = self
             .linear_combinations
@@ -321,11 +291,7 @@ impl Add<&Expression> for &Expression {
             .collect();
         let q_c = self.q_c + rhs.q_c;
 
-        Expression {
-            mul_terms,
-            linear_combinations,
-            q_c,
-        }
+        Expression { mul_terms, linear_combinations, q_c }
     }
 }
 
@@ -334,24 +300,14 @@ impl Neg for &Expression {
     fn neg(self) -> Self::Output {
         // XXX(med) : Implement an efficient way to do this
 
-        let mul_terms: Vec<_> = self
-            .mul_terms
-            .iter()
-            .map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r))
-            .collect();
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r)).collect();
 
-        let linear_combinations: Vec<_> = self
-            .linear_combinations
-            .iter()
-            .map(|(q_k, w_k)| (-*q_k, *w_k))
-            .collect();
+        let linear_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_k, w_k)| (-*q_k, *w_k)).collect();
         let q_c = -self.q_c;
 
-        Expression {
-            mul_terms,
-            linear_combinations,
-            q_c,
-        }
+        Expression { mul_terms, linear_combinations, q_c }
     }
 }
 
@@ -364,11 +320,7 @@ impl Sub<&Expression> for &Expression {
 
 impl From<&FieldElement> for Expression {
     fn from(constant: &FieldElement) -> Expression {
-        Expression {
-            q_c: *constant,
-            linear_combinations: Vec::new(),
-            mul_terms: Vec::new(),
-        }
+        Expression { q_c: *constant, linear_combinations: Vec::new(), mul_terms: Vec::new() }
     }
 }
 impl From<&Linear> for Expression {
@@ -413,9 +365,7 @@ impl Sub<&UnknownWitness> for &Expression {
     type Output = Expression;
     fn sub(self, rhs: &UnknownWitness) -> Expression {
         let mut cloned = self.clone();
-        cloned
-            .linear_combinations
-            .insert(0, (-FieldElement::one(), rhs.as_witness()));
+        cloned.linear_combinations.insert(0, (-FieldElement::one(), rhs.as_witness()));
         cloned
     }
 }

--- a/acir/src/native_types/linear.rs
+++ b/acir/src/native_types/linear.rs
@@ -19,11 +19,7 @@ impl Linear {
         self.mul_scale.is_one() && self.add_scale.is_zero()
     }
     pub fn from_witness(witness: Witness) -> Linear {
-        Linear {
-            mul_scale: FieldElement::one(),
-            witness,
-            add_scale: FieldElement::zero(),
-        }
+        Linear { mul_scale: FieldElement::one(), witness, add_scale: FieldElement::zero() }
     }
     // XXX: This is true for the NPC languages that we use, are there any where this is not true?
     pub const fn can_defer_constraint(&self) -> bool {
@@ -38,11 +34,7 @@ impl From<Witness> for Linear {
 }
 impl From<FieldElement> for Linear {
     fn from(element: FieldElement) -> Linear {
-        Linear {
-            add_scale: element,
-            witness: Witness::default(),
-            mul_scale: FieldElement::zero(),
-        }
+        Linear { add_scale: element, witness: Witness::default(), mul_scale: FieldElement::zero() }
     }
 }
 
@@ -63,11 +55,7 @@ impl Neg for &Linear {
     type Output = Linear;
     fn neg(self) -> Self::Output {
         // -(Ax + B) = -Ax - B
-        Linear {
-            add_scale: -self.add_scale,
-            witness: self.witness,
-            mul_scale: -self.mul_scale,
-        }
+        Linear { add_scale: -self.add_scale, witness: self.witness, mul_scale: -self.mul_scale }
     }
 }
 
@@ -109,11 +97,7 @@ impl Mul<&Linear> for &Linear {
             lc
         };
 
-        Expression {
-            mul_terms,
-            linear_combinations,
-            q_c: bd,
-        }
+        Expression { mul_terms, linear_combinations, q_c: bd }
     }
 }
 impl Mul<&FieldElement> for &Linear {

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -128,9 +128,7 @@ impl<'de, T: ark_ff::PrimeField> Deserialize<'de> for FieldElement<T> {
         let s = <&str>::deserialize(deserializer)?;
         match Self::from_hex(s) {
             Some(value) => Ok(value),
-            None => Err(serde::de::Error::custom(format!(
-                "Invalid hex for FieldElement: {s}",
-            ))),
+            None => Err(serde::de::Error::custom(format!("Invalid hex for FieldElement: {s}",))),
         }
     }
 }

--- a/acvm/src/compiler/optimizers/general.rs
+++ b/acvm/src/compiler/optimizers/general.rs
@@ -18,8 +18,7 @@ pub fn remove_zero_coefficients(mut gate: Expression) -> Expression {
     // Check the mul terms
     gate.mul_terms.retain(|(scale, _, _)| !scale.is_zero());
     // Check the linear combination terms
-    gate.linear_combinations
-        .retain(|(scale, _)| !scale.is_zero());
+    gate.linear_combinations.retain(|(scale, _)| !scale.is_zero());
     gate
 }
 
@@ -33,14 +32,9 @@ pub fn simplify_mul_terms(mut gate: Expression) -> Expression {
         // Sort using rust sort algorithm
         pair.sort();
 
-        *hash_map
-            .entry((pair[0], pair[1]))
-            .or_insert_with(FieldElement::zero) += scale;
+        *hash_map.entry((pair[0], pair[1])).or_insert_with(FieldElement::zero) += scale;
     }
 
-    gate.mul_terms = hash_map
-        .into_iter()
-        .map(|((w_l, w_r), scale)| (scale, w_l, w_r))
-        .collect();
+    gate.mul_terms = hash_map.into_iter().map(|((w_l, w_r), scale)| (scale, w_l, w_r)).collect();
     gate
 }

--- a/acvm/src/compiler/transformers/csat.rs
+++ b/acvm/src/compiler/transformers/csat.rs
@@ -99,14 +99,10 @@ impl CSatTransformer {
             // Check if this pair is present in the simplified fan-in
             // We are assuming that the fan-in/fan-out has been simplified.
             // Note this function is not public, and can only be called within the optimize method, so this guarantee will always hold
-            let index_wl = gate
-                .linear_combinations
-                .iter()
-                .position(|(_scale, witness)| *witness == pair.1);
-            let index_wr = gate
-                .linear_combinations
-                .iter()
-                .position(|(_scale, witness)| *witness == pair.2);
+            let index_wl =
+                gate.linear_combinations.iter().position(|(_scale, witness)| *witness == pair.1);
+            let index_wr =
+                gate.linear_combinations.iter().position(|(_scale, witness)| *witness == pair.2);
 
             match (index_wl, index_wr) {
                 (None, _) => {
@@ -172,16 +168,12 @@ impl CSatTransformer {
                     let inter_var = Witness(intermediate_variables.len() as u32 + num_witness);
 
                     // Constrain the gate to the intermediate variable
-                    intermediate_gate
-                        .linear_combinations
-                        .push((-FieldElement::one(), inter_var));
+                    intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
                     // Add intermediate gate to the map
                     intermediate_variables.insert(inter_var, intermediate_gate);
 
                     // Add intermediate variable to the new gate instead of the full gate
-                    new_gate
-                        .linear_combinations
-                        .push((FieldElement::one(), inter_var));
+                    new_gate.linear_combinations.push((FieldElement::one(), inter_var));
                 }
             };
             // Remove this term as we are finished processing it
@@ -190,9 +182,7 @@ impl CSatTransformer {
 
         // Add the rest of the elements back into the new_gate
         new_gate.mul_terms.extend(gate.mul_terms.clone());
-        new_gate
-            .linear_combinations
-            .extend(gate.linear_combinations.clone());
+        new_gate.linear_combinations.extend(gate.linear_combinations.clone());
         new_gate.q_c = gate.q_c;
         new_gate.sort();
         new_gate
@@ -259,16 +249,13 @@ impl CSatTransformer {
             // Push mul term into the gate
             intermediate_gate.mul_terms.push(mul_term);
             // Constrain it to be equal to the intermediate variable
-            intermediate_gate
-                .linear_combinations
-                .push((-FieldElement::one(), inter_var));
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
             intermediate_variables.insert(inter_var, intermediate_gate);
 
             // Add intermediate variable as a part of the fan-in for the original gate
-            gate.linear_combinations
-                .push((FieldElement::one(), inter_var));
+            gate.linear_combinations.push((FieldElement::one(), inter_var));
         }
 
         // Remove all of the mul terms as we have intermediate variables to represent them now
@@ -305,9 +292,7 @@ impl CSatTransformer {
 
             added.push((FieldElement::one(), inter_var));
 
-            intermediate_gate
-                .linear_combinations
-                .push((-FieldElement::one(), inter_var));
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
 
             // Add intermediate gate and variable to map
             intermediate_variables.insert(inter_var, intermediate_gate);

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -103,10 +103,7 @@ pub trait PartialWitnessGenerator {
     ) -> bool {
         // This call to .any returns true, if any of the witnesses do not have assignments
         // We then use `!`, so it returns false if any of the witnesses do not have assignments
-        !func_call
-            .inputs
-            .iter()
-            .any(|input| !initial_witness.contains_key(&input.witness))
+        !func_call.inputs.iter().any(|input| !initial_witness.contains_key(&input.witness))
     }
 
     fn solve_directives(

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -23,13 +23,7 @@ pub fn solve_directives(
             initial_witness.insert(*result, inverse);
             Ok(())
         }
-        Directive::Quotient {
-            a,
-            b,
-            q,
-            r,
-            predicate,
-        } => {
+        Directive::Quotient { a, b, q, r, predicate } => {
             let val_a = get_value(a, initial_witness)?;
             let val_b = get_value(b, initial_witness)?;
 
@@ -84,12 +78,7 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::ToRadix {
-            a,
-            b,
-            radix,
-            is_little_endian,
-        } => {
+        Directive::ToRadix { a, b, radix, is_little_endian } => {
             let value_a = get_value(a, initial_witness)?;
 
             let big_integer = BigUint::from_bytes_be(&value_a.to_be_bytes());
@@ -166,12 +155,7 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::PermutationSort {
-            inputs: a,
-            tuple,
-            bits,
-            sort_by,
-        } => {
+        Directive::PermutationSort { inputs: a, tuple, bits, sort_by } => {
             let mut val_a = Vec::new();
             let mut base = Vec::new();
             for (i, element) in a.iter().enumerate() {
@@ -199,11 +183,7 @@ pub fn solve_directives(
             let b = val_a.iter().map(|a| *a.last().unwrap()).collect();
             let control = route(base, b);
             for (w, value) in bits.iter().zip(control) {
-                let value = if value {
-                    FieldElement::one()
-                } else {
-                    FieldElement::zero()
-                };
+                let value = if value { FieldElement::one() } else { FieldElement::zero() };
                 insert_witness(*w, value, initial_witness)?;
             }
             Ok(())

--- a/acvm/src/pwg/hash.rs
+++ b/acvm/src/pwg/hash.rs
@@ -39,9 +39,7 @@ fn generic_hash_256<D: Digest>(
     }
     let result = hasher.finalize();
     for i in 0..32 {
-        initial_witness.insert(
-            gadget_call.outputs[i],
-            FieldElement::from_be_bytes_reduce(&[result[i]]),
-        );
+        initial_witness
+            .insert(gadget_call.outputs[i], FieldElement::from_be_bytes_reduce(&[result[i]]));
     }
 }

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -10,10 +10,7 @@ pub fn solve_logic_opcode(
     match func_call.name {
         BlackBoxFunc::AND => LogicSolver::solve_and_gate(initial_witness, func_call),
         BlackBoxFunc::XOR => LogicSolver::solve_xor_gate(initial_witness, func_call),
-        _ => Err(OpcodeResolutionError::UnexpectedOpcode(
-            "logic opcode",
-            func_call.name,
-        )),
+        _ => Err(OpcodeResolutionError::UnexpectedOpcode("logic opcode", func_call.name)),
     }
 }
 
@@ -67,10 +64,7 @@ pub(crate) fn extract_input_output(
     let result = &bb_func_call.outputs[0];
 
     // The num_bits variable should be the same for all witnesses
-    assert_eq!(
-        a.num_bits, b.num_bits,
-        "number of bits specified for each input must be the same"
-    );
+    assert_eq!(a.num_bits, b.num_bits, "number of bits specified for each input must be the same");
 
     let num_bits = a.num_bits;
 

--- a/acvm/src/pwg/range.rs
+++ b/acvm/src/pwg/range.rs
@@ -25,10 +25,7 @@ pub fn solve_range_opcode(
     // For the range constraint, we know that the input size should be one
     assert_eq!(defined_input_size, 1);
 
-    let input = func_call
-        .inputs
-        .first()
-        .expect("infallible: checked that input size is 1");
+    let input = func_call.inputs.first().expect("infallible: checked that input size is 1");
 
     let w_value = witness_to_value(initial_witness, input.witness)?;
 


### PR DESCRIPTION
# Description

## Summary of changes

This repository previously did not have a `.rustfmt.toml` file. I've copied over the file from the main noir repo and formatting is now noticeably more compact.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.