### PR TITLE
chore: add keccak to CSpell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -19,6 +19,7 @@
         "endianness",
         "euclidian",
         "hasher",
+        "keccak",
         "Merkle",
         "OddRange",
         "Pedersen",


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

We're getting a lot of spelling warnings appear (e.g. https://github.com/noir-lang/acvm/pull/107/files) so I've added this to the dictionary.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
