### PR TITLE
feat!: update `ProofSystemCompiler` to not take ownership of keys

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -170,7 +170,7 @@ pub trait ProofSystemCompiler {
         &self,
         circuit: &Circuit,
         witness_values: BTreeMap<Witness, FieldElement>,
-        proving_key: Vec<u8>,
+        proving_key: &[u8],
     ) -> Vec<u8>;
 
     /// Verifies a Proof, given the circuit description, the circuit's public inputs, and the verification key
@@ -179,7 +179,7 @@ pub trait ProofSystemCompiler {
         proof: &[u8],
         public_inputs: Vec<FieldElement>,
         circuit: &Circuit,
-        verification_key: Vec<u8>,
+        verification_key: &[u8],
     ) -> bool;
 }
 


### PR DESCRIPTION
# Related issue(s)

Resolves #110 

# Description

## Summary of changes

I've changed the argument types from `Vec<u8>` to `&[u8]`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
