### PR TITLE
feat(acvm): add `eth_contract_from_vk` to `SmartContract

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -115,6 +115,8 @@ pub trait PartialWitnessGenerator {
 }
 
 pub trait SmartContract {
+    // TODO: Allow a backend to support multiple smart contract platforms
+
     /// Takes an ACIR circuit, the number of witnesses and the number of public inputs
     /// Then returns an Ethereum smart contract
     ///

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -115,13 +115,6 @@ pub trait PartialWitnessGenerator {
 }
 
 pub trait SmartContract {
-    // Takes a verification  key and produces a smart contract
-    // The platform indicator allows a backend to support multiple smart contract platforms
-    //
-    // fn verification_key(&self, platform: u8, vk: &[u8]) -> &[u8] {
-    //     todo!("currently the backend is not configured to use this.")
-    // }
-
     /// Takes an ACIR circuit, the number of witnesses and the number of public inputs
     /// Then returns an Ethereum smart contract
     ///
@@ -129,7 +122,11 @@ pub trait SmartContract {
     /// This deprecation may happen in two stages:
     /// The first stage will remove `num_witnesses` and `num_public_inputs` parameters.
     /// If we cannot avoid `num_witnesses`, it can be added into the Circuit struct.
+    #[deprecated]
     fn eth_contract_from_cs(&self, circuit: Circuit) -> String;
+
+    /// Returns an Ethereum smart contract to verify proofs against a given verification key.
+    fn eth_contract_from_vk(&self, verification_key: &[u8]) -> String;
 }
 
 pub trait ProofSystemCompiler {


### PR DESCRIPTION
chore: deprecate `eth_contract_from_cs`

# Related issue(s)

Resolves #102 

# Description

## Summary of changes

`eth_contract_from_cs` is now deprecated and `eth_contract_from_vk` has been added which takes a `&[u8]` rather than a `Circuit`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
