### PR TITLE
fix(ci): publish acvm_stdlib before acvm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,14 +35,15 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
 
-      - name: Publish acvm
-        run: |
-          cargo publish --package acvm
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
-
       - name: Publish acvm_stdlib
         run: |
           cargo publish --package acvm_stdlib
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+
+      - name: Publish acvm
+        run: |
+          cargo publish --package acvm
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
+  


### PR DESCRIPTION
# Related issue(s)

Resolves issue with publishing where `acvm` can't find the correct version of `acvm_stdlib`

https://github.com/noir-lang/acvm/actions/runs/4262171236/jobs/7417352533

# Description

## Summary of changes

I've swapped acvm and acvm_stdlib so that the acvm_stdlib crate is published first.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
