### PR TITLE
chore(ci): split off spellcheck from rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,14 +14,3 @@ jobs:
   format:
     name: cargo fmt
     uses: noir-lang/.github/.github/workflows/rust-format.yml@main
-
-  spellcheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: streetsidesoftware/cspell-action@v2
-        with:
-          files: |
-            **/*.{md,rs}
-          incremental_files_only: true # Run this action on files which have changed in PR
-          strict: false # Do not fail, if a spelling mistake is found (This can be annoying for contributors)

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,13 @@
+name: Spellcheck
+
+on: [push]
+
+# This will cancel previous runs when a branch or PR is updated
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  spellcheck:
+    name: Spellcheck
+    uses: noir-lang/.github/.github/workflows/spellcheck.yml@main


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

This is the ACVM equivalent of the PR https://github.com/noir-lang/noir/pull/858

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
