### PR TITLE
chore: remove unused crate dependencies

### DIFF
--- a/acir/src/lib.rs
+++ b/acir/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unused_crate_dependencies)]
+
 // Arbitrary Circuit Intermediate Representation
 
 pub mod circuit;

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -10,10 +10,8 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2.workspace = true
 hex.workspace = true
 num-bigint.workspace = true
-num-traits.workspace = true
 serde.workspace = true
 
 
@@ -24,7 +22,6 @@ ark-bls12-381 = { version = "^0.4.0", optional = true, default-features = false,
     "curve",
 ] }
 ark-ff = { version = "^0.4.0", optional = true, default-features = false }
-ark-serialize = { version = "^0.4.0", default-features = false }
 
 cfg-if = "1.0.0"
 

--- a/acir_field/src/lib.rs
+++ b/acir_field/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unused_crate_dependencies)]
+
 cfg_if::cfg_if! {
     if #[cfg(feature = "bn254")] {
         mod generic_ark;

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -33,5 +33,4 @@ bn254 = ["acir/bn254"]
 bls12_381 = ["acir/bls12_381"]
 
 [dev-dependencies]
-tempfile = "3.2.0"
 rand = "0.8.5"

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(unused_crate_dependencies)]
+
 // Key is currently {NPComplete_lang}_{OptionalFanIn}_ProofSystem_OrgName
 // Org name is needed because more than one implementation of the same proof system may arise
 

--- a/stdlib/src/lib.rs
+++ b/stdlib/src/lib.rs
@@ -1,2 +1,4 @@
+#![warn(unused_crate_dependencies)]
+
 pub mod fallback;
 pub mod helpers;


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

Cargo now throws warnings if we've defined a dependency but don't make use of it.

## Dependency additions / changes

Removed `blake2`, `num_traits` and `ark-serialize` from `acir_field`.

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
