### PR TITLE
chore(acir)!: rename `term_multiplication` to `push_multiplication_term`

### DIFF
--- a/acir/src/native_types/arithmetic.rs
+++ b/acir/src/native_types/arithmetic.rs
@@ -134,13 +134,17 @@ impl Expression {
             let mul_term_coeff = read_field_element::<FIELD_ELEMENT_NUM_BYTES, _>(&mut reader)?;
             let mul_term_lhs = read_u32(&mut reader)?;
             let mul_term_rhs = read_u32(&mut reader)?;
-            expr.term_multiplication(mul_term_coeff, Witness(mul_term_lhs), Witness(mul_term_rhs))
+            expr.push_multiplication_term(
+                mul_term_coeff,
+                Witness(mul_term_lhs),
+                Witness(mul_term_rhs),
+            )
         }
 
         for _ in 0..num_lin_comb_terms {
             let lin_term_coeff = read_field_element::<FIELD_ELEMENT_NUM_BYTES, _>(&mut reader)?;
             let lin_term_variable = read_u32(&mut reader)?;
-            expr.term_addition(lin_term_coeff, Witness(lin_term_variable))
+            expr.push_addition_term(lin_term_coeff, Witness(lin_term_variable))
         }
 
         let q_c = read_field_element::<FIELD_ELEMENT_NUM_BYTES, _>(&mut reader)?;
@@ -154,10 +158,11 @@ impl Expression {
         self.mul_terms.is_empty()
     }
 
-    pub fn term_addition(&mut self, coefficient: acir_field::FieldElement, variable: Witness) {
+    pub fn push_addition_term(&mut self, coefficient: acir_field::FieldElement, variable: Witness) {
         self.linear_combinations.push((coefficient, variable))
     }
-    pub fn term_multiplication(
+
+    pub fn push_multiplication_term(
         &mut self,
         coefficient: acir_field::FieldElement,
         lhs: Witness,
@@ -445,8 +450,8 @@ fn serialization_roundtrip() {
 
     //
     let mut expr = Expression::default();
-    expr.term_addition(FieldElement::from(123i128), Witness(20u32));
-    expr.term_multiplication(FieldElement::from(123i128), Witness(20u32), Witness(123u32));
+    expr.push_addition_term(FieldElement::from(123i128), Witness(20u32));
+    expr.push_multiplication_term(FieldElement::from(123i128), Witness(20u32), Witness(123u32));
     expr.q_c = FieldElement::from(789456i128);
 
     let (expr, got_expr) = read_write(expr);

--- a/stdlib/src/fallback.rs
+++ b/stdlib/src/fallback.rs
@@ -54,14 +54,14 @@ pub(crate) fn bit_decomposition(
     for &bit in &bit_vector {
         // Bit constraint to ensure each bit is a zero or one; bit^2 - bit = 0
         let mut expr = Expression::default();
-        expr.term_multiplication(FieldElement::one(), bit, bit);
-        expr.term_addition(-FieldElement::one(), bit);
+        expr.push_multiplication_term(FieldElement::one(), bit, bit);
+        expr.push_addition_term(-FieldElement::one(), bit);
         binary_exprs.push(Opcode::Arithmetic(expr));
 
         // Constraint to ensure that the bits are constrained to be a bit decomposition
         // of the input
         // ie \sum 2^i * x_i = input
-        bit_decomp_constraint.term_addition(-two_pow, bit);
+        bit_decomp_constraint.push_addition_term(-two_pow, bit);
         two_pow = two * two_pow;
     }
 
@@ -105,10 +105,10 @@ pub fn and(
     // expected output; ie result = \sum 2^i x_i * y_i
     let mut and_expr = Expression::default();
     for (a_bit, b_bit) in a_bits.into_iter().zip(b_bits) {
-        and_expr.term_multiplication(two_pow, a_bit, b_bit);
+        and_expr.push_multiplication_term(two_pow, a_bit, b_bit);
         two_pow = two * two_pow;
     }
-    and_expr.term_addition(-FieldElement::one(), result);
+    and_expr.push_addition_term(-FieldElement::one(), result);
 
     and_expr.sort();
 
@@ -144,12 +144,12 @@ pub fn xor(
     // TODO: check this is the correct arithmetization
     let mut xor_expr = Expression::default();
     for (a_bit, b_bit) in a_bits.into_iter().zip(b_bits) {
-        xor_expr.term_addition(two_pow, a_bit);
-        xor_expr.term_addition(two_pow, b_bit);
+        xor_expr.push_addition_term(two_pow, a_bit);
+        xor_expr.push_addition_term(two_pow, b_bit);
         two_pow = two * two_pow;
-        xor_expr.term_multiplication(-two_pow, a_bit, b_bit);
+        xor_expr.push_multiplication_term(-two_pow, a_bit, b_bit);
     }
-    xor_expr.term_addition(-FieldElement::one(), result);
+    xor_expr.push_addition_term(-FieldElement::one(), result);
 
     xor_expr.sort();
     let mut new_gates = Vec::new();


### PR DESCRIPTION
chore(acir)!: rename `term_addition` to `push_addition_term`

# Related issue(s)

Resolves one item from https://github.com/noir-lang/acvm/issues/53

> term_multiplication() and term_addition() are not clear and should be renamed into push_multiplication_term() and push_linear_term()

# Description

## Summary of changes

These two methods have been renamed to be clearer about what they do.

This is a relatively minor change but is breaking. We should delay merging until we are going to have a breaking release.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
