### PR TITLE
feat(acir): implement `Expression::from()` for both values and references

### DIFF
--- a/acir/src/native_types/arithmetic.rs
+++ b/acir/src/native_types/arithmetic.rs
@@ -318,11 +318,30 @@ impl Sub<&Expression> for &Expression {
     }
 }
 
-impl From<&FieldElement> for Expression {
-    fn from(constant: &FieldElement) -> Expression {
-        Expression { q_c: *constant, linear_combinations: Vec::new(), mul_terms: Vec::new() }
+impl From<FieldElement> for Expression {
+    fn from(constant: FieldElement) -> Expression {
+        Expression { q_c: constant, linear_combinations: Vec::new(), mul_terms: Vec::new() }
     }
 }
+
+impl From<&FieldElement> for Expression {
+    fn from(constant: &FieldElement) -> Expression {
+        (*constant).into()
+    }
+}
+
+impl From<Witness> for Expression {
+    fn from(wit: Witness) -> Expression {
+        Linear::from_witness(wit).into()
+    }
+}
+
+impl From<&Witness> for Expression {
+    fn from(wit: &Witness) -> Expression {
+        (*wit).into()
+    }
+}
+
 impl From<&Linear> for Expression {
     fn from(lin: &Linear) -> Expression {
         Expression {
@@ -335,11 +354,6 @@ impl From<&Linear> for Expression {
 impl From<Linear> for Expression {
     fn from(lin: Linear) -> Expression {
         Expression::from(&lin)
-    }
-}
-impl From<&Witness> for Expression {
-    fn from(wit: &Witness) -> Expression {
-        Linear::from_witness(*wit).into()
     }
 }
 


### PR DESCRIPTION
# Related issue(s)


# Description

## Summary of changes

We currently only implement `Expression::from<&Witness>` and `Expression::from<&FieldElement>`, I've implemented `Expression::from<Witness>` and `Expression::from<FieldElement>` as otherwise we need to borrow these values before we can convert them.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
