### PR TITLE
chore(acir): silence deprecation warning in test

### DIFF
--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -207,6 +207,7 @@ mod test {
         assert_eq!(circuit, deserialized);
     }
 
+    #[allow(deprecated)]
     #[test]
     fn test_to_byte() {
         let circuit = Circuit {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

This test is testing deprecated code so having a warning appear here doesn't make sense.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
