### PR TITLE
chore(acvm): implement `From` for OpcodeNotSolvable

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -38,7 +38,7 @@ pub enum OpcodeNotSolvable {
 #[derive(PartialEq, Eq, Debug, Error)]
 pub enum OpcodeResolutionError {
     #[error("cannot solve opcode: {0}")]
-    OpcodeNotSolvable(OpcodeNotSolvable),
+    OpcodeNotSolvable(#[from] OpcodeNotSolvable),
     #[error("backend does not currently support the {0} opcode. ACVM does not currently have a fallback for this opcode.")]
     UnsupportedBlackBoxFunc(BlackBoxFunc),
     #[error("could not satisfy all constraints")]

--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -27,9 +27,7 @@ pub fn witness_to_value(
 ) -> Result<&FieldElement, OpcodeResolutionError> {
     match initial_witness.get(&witness) {
         Some(value) => Ok(value),
-        None => Err(OpcodeResolutionError::OpcodeNotSolvable(
-            OpcodeNotSolvable::MissingAssignment(witness.0),
-        )),
+        None => Err(OpcodeNotSolvable::MissingAssignment(witness.0).into()),
     }
 }
 // TODO: There is an issue open to decide on whether we need to get values from Expressions

--- a/acvm/src/pwg/arithmetic.rs
+++ b/acvm/src/pwg/arithmetic.rs
@@ -37,9 +37,7 @@ impl ArithmeticSolver {
 
         match (mul_result, gate_status) {
             (MulTerm::TooManyUnknowns, _) | (_, GateStatus::GateUnsolvable) => {
-                Err(OpcodeResolutionError::OpcodeNotSolvable(
-                    OpcodeNotSolvable::ExpressionHasTooManyUnknowns(gate.clone()),
-                ))
+                Err(OpcodeNotSolvable::ExpressionHasTooManyUnknowns(gate.clone()).into())
             }
             (MulTerm::OneUnknown(q, w1), GateStatus::GateSolvable(a, (b, w2))) => {
                 if w1 == w2 {
@@ -59,9 +57,7 @@ impl ArithmeticSolver {
                     }
                 } else {
                     // TODO: can we be more specific with this error?
-                    Err(OpcodeResolutionError::OpcodeNotSolvable(
-                        OpcodeNotSolvable::ExpressionHasTooManyUnknowns(gate.clone()),
-                    ))
+                    Err(OpcodeNotSolvable::ExpressionHasTooManyUnknowns(gate.clone()).into())
                 }
             }
             (MulTerm::OneUnknown(partial_prod, unknown_var), GateStatus::GateSatisfied(sum)) => {

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -116,11 +116,7 @@ pub fn solve_directives(
                     if i >= padding_len {
                         value = match decomposed_integer.get(i - padding_len) {
                             Some(digit) => FieldElement::from_be_bytes_reduce(&[*digit]),
-                            None => {
-                                return Err(OpcodeResolutionError::OpcodeNotSolvable(
-                                    OpcodeNotSolvable::UnreachableCode,
-                                ))
-                            }
+                            None => return Err(OpcodeNotSolvable::UnreachableCode.into()),
                         };
                     }
                     insert_value(witness, value, initial_witness)?


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

We now derive `OpcodeResolutionError::from<OpcodeNotSolvable>()` which avoids some wrapping of errors.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
