### PR TITLE
chore!(acir): remove is_little_endian from to_radix

### DIFF
--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -43,7 +43,7 @@ pub enum Directive {
     },
 
     //decomposition of a: a=\sum b[i]*radix^i where b is an array of witnesses < radix in little endian form
-    ToRadixLe {
+    ToLeRadix {
         a: Expression,
         b: Vec<Witness>,
         radix: u32,
@@ -67,7 +67,7 @@ impl Directive {
             Directive::Quotient { .. } => "quotient",
             Directive::Truncate { .. } => "truncate",
             Directive::OddRange { .. } => "odd_range",
-            Directive::ToRadixLe { .. } => "to_radix_le",
+            Directive::ToLeRadix { .. } => "to_le_radix",
             Directive::PermutationSort { .. } => "permutation_sort",
             Directive::Log { .. } => "log",
         }
@@ -78,7 +78,7 @@ impl Directive {
             Directive::Quotient { .. } => 1,
             Directive::Truncate { .. } => 2,
             Directive::OddRange { .. } => 3,
-            Directive::ToRadixLe { .. } => 4,
+            Directive::ToLeRadix { .. } => 4,
             Directive::Log { .. } => 5,
             Directive::PermutationSort { .. } => 6,
         }
@@ -116,7 +116,7 @@ impl Directive {
                 write_u32(&mut writer, r.witness_index())?;
                 write_u32(&mut writer, *bit_size)?;
             }
-            Directive::ToRadixLe { a, b, radix } => {
+            Directive::ToLeRadix { a, b, radix } => {
                 a.write(&mut writer)?;
                 write_u32(&mut writer, b.len() as u32)?;
                 for bit in b {
@@ -206,7 +206,7 @@ impl Directive {
 
                 let radix = read_u32(&mut reader)?;
 
-                Ok(Directive::ToRadixLe { a, b, radix })
+                Ok(Directive::ToLeRadix { a, b, radix })
             }
             6 => {
                 let tuple = read_u32(&mut reader)?;
@@ -285,14 +285,14 @@ fn serialization_roundtrip() {
     let odd_range =
         Directive::OddRange { a: Witness(1u32), b: Witness(2u32), r: Witness(3u32), bit_size: 32 };
 
-    let to_radix_le = Directive::ToRadixLe {
+    let to_le_radix = Directive::ToLeRadix {
         a: Expression::default(),
         b: vec![Witness(1u32), Witness(2u32), Witness(3u32), Witness(4u32)],
         radix: 4,
     };
 
     let directives =
-        vec![invert, quotient_none, quotient_predicate, truncate, odd_range, to_radix_le];
+        vec![invert, quotient_none, quotient_predicate, truncate, odd_range, to_le_radix];
 
     for directive in directives {
         let (dir, got_dir) = read_write(directive);

--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -42,12 +42,11 @@ pub enum Directive {
         bit_size: u32,
     },
 
-    //decomposition of a: a=\sum b[i]*radix^i where b is an array of witnesses < radix in either little endian or big endian form
-    ToRadix {
+    //decomposition of a: a=\sum b[i]*radix^i where b is an array of witnesses < radix in little endian form
+    ToRadixLe {
         a: Expression,
         b: Vec<Witness>,
         radix: u32,
-        is_little_endian: bool,
     },
 
     // Sort directive, using a sorting network
@@ -68,7 +67,7 @@ impl Directive {
             Directive::Quotient { .. } => "quotient",
             Directive::Truncate { .. } => "truncate",
             Directive::OddRange { .. } => "odd_range",
-            Directive::ToRadix { .. } => "to_radix",
+            Directive::ToRadixLe { .. } => "to_radix",
             Directive::PermutationSort { .. } => "permutation_sort",
             Directive::Log { .. } => "log",
         }
@@ -79,7 +78,7 @@ impl Directive {
             Directive::Quotient { .. } => 1,
             Directive::Truncate { .. } => 2,
             Directive::OddRange { .. } => 3,
-            Directive::ToRadix { .. } => 4,
+            Directive::ToRadixLe { .. } => 4,
             Directive::Log { .. } => 5,
             Directive::PermutationSort { .. } => 6,
         }
@@ -117,14 +116,13 @@ impl Directive {
                 write_u32(&mut writer, r.witness_index())?;
                 write_u32(&mut writer, *bit_size)?;
             }
-            Directive::ToRadix { a, b, radix, is_little_endian } => {
+            Directive::ToRadixLe { a, b, radix } => {
                 a.write(&mut writer)?;
                 write_u32(&mut writer, b.len() as u32)?;
                 for bit in b {
                     write_u32(&mut writer, bit.witness_index())?;
                 }
                 write_u32(&mut writer, *radix)?;
-                write_u32(&mut writer, *is_little_endian as u32)?;
             }
             Directive::PermutationSort { inputs: a, tuple, bits, sort_by } => {
                 write_u32(&mut writer, *tuple)?;
@@ -207,9 +205,8 @@ impl Directive {
                 }
 
                 let radix = read_u32(&mut reader)?;
-                let is_little_endian = read_u32(&mut reader)?;
 
-                Ok(Directive::ToRadix { a, b, radix, is_little_endian: is_little_endian == 1 })
+                Ok(Directive::ToRadixLe { a, b, radix })
             }
             6 => {
                 let tuple = read_u32(&mut reader)?;
@@ -288,29 +285,14 @@ fn serialization_roundtrip() {
     let odd_range =
         Directive::OddRange { a: Witness(1u32), b: Witness(2u32), r: Witness(3u32), bit_size: 32 };
 
-    let to_radix_le = Directive::ToRadix {
+    let to_radix_le = Directive::ToRadixLe {
         a: Expression::default(),
         b: vec![Witness(1u32), Witness(2u32), Witness(3u32), Witness(4u32)],
         radix: 4,
-        is_little_endian: true,
     };
 
-    let to_radix_be = Directive::ToRadix {
-        a: Expression::default(),
-        b: vec![Witness(1u32), Witness(2u32), Witness(3u32), Witness(4u32)],
-        radix: 4,
-        is_little_endian: false,
-    };
-
-    let directives = vec![
-        invert,
-        quotient_none,
-        quotient_predicate,
-        truncate,
-        odd_range,
-        to_radix_le,
-        to_radix_be,
-    ];
+    let directives =
+        vec![invert, quotient_none, quotient_predicate, truncate, odd_range, to_radix_le];
 
     for directive in directives {
         let (dir, got_dir) = read_write(directive);

--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -67,7 +67,7 @@ impl Directive {
             Directive::Quotient { .. } => "quotient",
             Directive::Truncate { .. } => "truncate",
             Directive::OddRange { .. } => "odd_range",
-            Directive::ToRadixLe { .. } => "to_radix",
+            Directive::ToRadixLe { .. } => "to_radix_le",
             Directive::PermutationSort { .. } => "permutation_sort",
             Directive::Log { .. } => "log",
         }

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -178,17 +178,16 @@ impl std::fmt::Display for Opcode {
                 )
             }
             Opcode::BlackBoxFuncCall(g) => write!(f, "{g}"),
-            Opcode::Directive(Directive::ToRadix { a, b, radix: _, is_little_endian }) => {
+            Opcode::Directive(Directive::ToRadixLe { a, b, radix: _ }) => {
                 write!(f, "DIR::TORADIX ")?;
                 write!(
                     f,
                     // TODO (Note): this assumes that the decomposed bits have contiguous witness indices
                     // This should be the case, however, we can also have a function which checks this
-                    "(_{}, [_{}..._{}], endianness: {})",
+                    "(_{}, [_{}..._{}] )",
                     a,
                     b.first().unwrap().witness_index(),
                     b.last().unwrap().witness_index(),
-                    if *is_little_endian { "little" } else { "big" }
                 )
             }
             Opcode::Directive(Directive::PermutationSort { inputs: a, tuple, bits, sort_by }) => {

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -178,7 +178,7 @@ impl std::fmt::Display for Opcode {
                 )
             }
             Opcode::BlackBoxFuncCall(g) => write!(f, "{g}"),
-            Opcode::Directive(Directive::ToRadixLe { a, b, radix: _ }) => {
+            Opcode::Directive(Directive::ToLeRadix { a, b, radix: _ }) => {
                 write!(f, "DIR::TORADIX ")?;
                 write!(
                     f,

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -35,8 +35,6 @@ pub enum OpcodeNotSolvable {
     MissingAssignment(u32),
     #[error("expression has too many unknowns {0}")]
     ExpressionHasTooManyUnknowns(Expression),
-    #[error("compiler error: unreachable code")]
-    UnreachableCode,
 }
 
 #[derive(PartialEq, Eq, Debug, Error)]

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -76,7 +76,7 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::ToRadixLe { a, b, radix } => {
+        Directive::ToLeRadix { a, b, radix } => {
             let value_a = get_value(a, initial_witness)?;
             let big_integer = BigUint::from_bytes_be(&value_a.to_be_bytes());
 

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -8,7 +8,7 @@ use acir::{
 use num_bigint::BigUint;
 use num_traits::{One, Zero};
 
-use crate::{OpcodeNotSolvable, OpcodeResolutionError};
+use crate::OpcodeResolutionError;
 
 use super::{get_value, insert_value, sorting::route, witness_to_value};
 
@@ -76,49 +76,30 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::ToRadix { a, b, radix, is_little_endian } => {
+        Directive::ToRadixLe { a, b, radix } => {
             let value_a = get_value(a, initial_witness)?;
             let big_integer = BigUint::from_bytes_be(&value_a.to_be_bytes());
 
-            if *is_little_endian {
-                // Decompose the integer into its radix digits in little endian form.
-                let decomposed_integer = big_integer.to_radix_le(*radix);
+            // Decompose the integer into its radix digits in little endian form.
+            let decomposed_integer = big_integer.to_radix_le(*radix);
 
-                if b.len() < decomposed_integer.len() {
-                    return Err(OpcodeResolutionError::UnsatisfiedConstrain);
-                }
-
-                for (i, witness) in b.iter().enumerate() {
-                    // Fetch the `i'th` digit from the decomposed integer list
-                    // and convert it to a field element.
-                    // If it is not available, which can happen when the decomposed integer
-                    // list is shorter than the witness list, we return 0.
-                    let value = match decomposed_integer.get(i) {
-                        Some(digit) => FieldElement::from_be_bytes_reduce(&[*digit]),
-                        None => FieldElement::zero(),
-                    };
-
-                    insert_value(witness, value, initial_witness)?
-                }
-            } else {
-                // Decompose the integer into its radix digits in big endian form.
-                let decomposed_integer = big_integer.to_radix_be(*radix);
-
-                // if it is big endian and the decompoased integer list is shorter
-                // than the witness list, pad the extra part with 0 first then
-                // add the decompsed interger list to the witness list.
-                let padding_len = b.len() - decomposed_integer.len();
-                let mut value = FieldElement::zero();
-                for (i, witness) in b.iter().enumerate() {
-                    if i >= padding_len {
-                        value = match decomposed_integer.get(i - padding_len) {
-                            Some(digit) => FieldElement::from_be_bytes_reduce(&[*digit]),
-                            None => return Err(OpcodeNotSolvable::UnreachableCode.into()),
-                        };
-                    }
-                    insert_value(witness, value, initial_witness)?
-                }
+            if b.len() < decomposed_integer.len() {
+                return Err(OpcodeResolutionError::UnsatisfiedConstrain);
             }
+
+            for (i, witness) in b.iter().enumerate() {
+                // Fetch the `i'th` digit from the decomposed integer list
+                // and convert it to a field element.
+                // If it is not available, which can happen when the decomposed integer
+                // list is shorter than the witness list, we return 0.
+                let value = match decomposed_integer.get(i) {
+                    Some(digit) => FieldElement::from_be_bytes_reduce(&[*digit]),
+                    None => FieldElement::zero(),
+                };
+
+                insert_value(witness, value, initial_witness)?
+            }
+
             Ok(())
         }
         Directive::OddRange { a, b, r, bit_size } => {

--- a/stdlib/src/fallback.rs
+++ b/stdlib/src/fallback.rs
@@ -38,11 +38,10 @@ pub(crate) fn bit_decomposition(
     }
 
     // Next create a directive which computes those bits.
-    new_gates.push(Opcode::Directive(Directive::ToRadix {
+    new_gates.push(Opcode::Directive(Directive::ToRadixLe {
         a: gate.clone(),
         b: bit_vector.clone(),
         radix: 2,
-        is_little_endian: true,
     }));
 
     // Now apply constraints to the bits such that they are the bit decomposition

--- a/stdlib/src/fallback.rs
+++ b/stdlib/src/fallback.rs
@@ -38,7 +38,7 @@ pub(crate) fn bit_decomposition(
     }
 
     // Next create a directive which computes those bits.
-    new_gates.push(Opcode::Directive(Directive::ToRadixLe {
+    new_gates.push(Opcode::Directive(Directive::ToLeRadix {
         a: gate.clone(),
         b: bit_vector.clone(),
         radix: 2,


### PR DESCRIPTION

# Description

## Summary of changes

In order to keep ACIR simple, I remove the endianness handling so that it only support to_radix_le. The gate as been renamed accordingly.

# Checklist

- [ ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

