### PR TITLE
fix!(acvm): report an error when solver is stalled

### DIFF
--- a/acvm/src/pwg/range.rs
+++ b/acvm/src/pwg/range.rs
@@ -17,7 +17,7 @@ pub fn solve_range_opcode(
     if num_arguments != defined_input_size as usize {
         return Err(OpcodeResolutionError::IncorrectNumFunctionArguments(
             defined_input_size as usize,
-            BlackBoxFunc::RANGE,
+            BlackBoxFunc::RANGE.name().to_string(),
             num_arguments,
         ));
     }


### PR DESCRIPTION
# Description

## Summary of changes

The PR distinguish expected outcomes from solving a gate vs errors happening during solving. This allows us to report an error when the solver is stalled instead of infinite loop/stack overflow.

## Dependency additions / changes

I believe the backend needs to be updated.

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

