### PR TITLE
chore(acvm)!: remove `prove_with_meta` and `verify_from_cs` from `ProofSystemCompiler`

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -143,23 +143,9 @@ pub trait ProofSystemCompiler {
     /// as this in most cases will be inefficient. For this reason, we want to throw a hard error
     /// if the language and proof system does not line up.
     fn np_language(&self) -> Language;
+
     // Returns true if the backend supports the selected black box function
     fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool;
-
-    #[deprecated]
-    fn prove_with_meta(
-        &self,
-        circuit: Circuit,
-        witness_values: BTreeMap<Witness, FieldElement>,
-    ) -> Vec<u8>;
-
-    #[deprecated]
-    fn verify_from_cs(
-        &self,
-        proof: &[u8],
-        public_inputs: Vec<FieldElement>,
-        circuit: Circuit,
-    ) -> bool;
 
     /// Returns the number of gates in a circuit
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> u32;


### PR DESCRIPTION

# Related issue(s)

Resolves #139 

# Description

## Summary of changes

I've removed the deprecated methods from `ProofSystemCompiler` so that they no longer need to be implemented by backends.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
