### PR TITLE
chore(acvm)!: Remove truncate and oddrange directives

### DIFF
--- a/acir/src/circuit/directives.rs
+++ b/acir/src/circuit/directives.rs
@@ -26,22 +26,6 @@ pub enum Directive {
         predicate: Option<Expression>,
     },
 
-    //Reduces the value of a modulo 2^bit_size and stores the result in b: a= c*2^bit_size + b
-    Truncate {
-        a: Expression,
-        b: Witness,
-        c: Witness,
-        bit_size: u32,
-    },
-
-    //Computes the highest bit b of a: a = b*2^(bit_size-1) + r, where a<2^bit_size, b is 0 or 1 and r<2^(bit_size-1)
-    OddRange {
-        a: Witness,
-        b: Witness,
-        r: Witness,
-        bit_size: u32,
-    },
-
     //decomposition of a: a=\sum b[i]*radix^i where b is an array of witnesses < radix in little endian form
     ToLeRadix {
         a: Expression,
@@ -65,8 +49,6 @@ impl Directive {
         match self {
             Directive::Invert { .. } => "invert",
             Directive::Quotient { .. } => "quotient",
-            Directive::Truncate { .. } => "truncate",
-            Directive::OddRange { .. } => "odd_range",
             Directive::ToLeRadix { .. } => "to_le_radix",
             Directive::PermutationSort { .. } => "permutation_sort",
             Directive::Log { .. } => "log",
@@ -76,11 +58,9 @@ impl Directive {
         match self {
             Directive::Invert { .. } => 0,
             Directive::Quotient { .. } => 1,
-            Directive::Truncate { .. } => 2,
-            Directive::OddRange { .. } => 3,
-            Directive::ToLeRadix { .. } => 4,
-            Directive::Log { .. } => 5,
-            Directive::PermutationSort { .. } => 6,
+            Directive::ToLeRadix { .. } => 2,
+            Directive::Log { .. } => 3,
+            Directive::PermutationSort { .. } => 4,
         }
     }
 
@@ -103,18 +83,6 @@ impl Directive {
                 if let Some(pred) = predicate {
                     pred.write(&mut writer)?;
                 }
-            }
-            Directive::Truncate { a, b, c, bit_size } => {
-                a.write(&mut writer)?;
-                write_u32(&mut writer, b.witness_index())?;
-                write_u32(&mut writer, c.witness_index())?;
-                write_u32(&mut writer, *bit_size)?;
-            }
-            Directive::OddRange { a, b, r, bit_size } => {
-                write_u32(&mut writer, a.witness_index())?;
-                write_u32(&mut writer, b.witness_index())?;
-                write_u32(&mut writer, r.witness_index())?;
-                write_u32(&mut writer, *bit_size)?;
             }
             Directive::ToLeRadix { a, b, radix } => {
                 a.write(&mut writer)?;
@@ -183,20 +151,6 @@ impl Directive {
             }
             2 => {
                 let a = Expression::read(&mut reader)?;
-                let b = Witness(read_u32(&mut reader)?);
-                let c = Witness(read_u32(&mut reader)?);
-                let bit_size = read_u32(&mut reader)?;
-                Ok(Directive::Truncate { a, b, c, bit_size })
-            }
-            3 => {
-                let a = Witness(read_u32(&mut reader)?);
-                let b = Witness(read_u32(&mut reader)?);
-                let r = Witness(read_u32(&mut reader)?);
-                let bit_size = read_u32(&mut reader)?;
-                Ok(Directive::OddRange { a, b, r, bit_size })
-            }
-            4 => {
-                let a = Expression::read(&mut reader)?;
                 let b_len = read_u32(&mut reader)?;
                 let mut b = Vec::with_capacity(b_len as usize);
                 for _ in 0..b_len {
@@ -208,7 +162,7 @@ impl Directive {
 
                 Ok(Directive::ToLeRadix { a, b, radix })
             }
-            6 => {
+            3 => {
                 let tuple = read_u32(&mut reader)?;
                 let a_len = read_u32(&mut reader)?;
                 let mut a = Vec::with_capacity(a_len as usize);
@@ -275,16 +229,6 @@ fn serialization_roundtrip() {
         predicate: Some(Expression::default()),
     };
 
-    let truncate = Directive::Truncate {
-        a: Expression::default(),
-        b: Witness(2u32),
-        c: Witness(3u32),
-        bit_size: 123,
-    };
-
-    let odd_range =
-        Directive::OddRange { a: Witness(1u32), b: Witness(2u32), r: Witness(3u32), bit_size: 32 };
-
     let to_le_radix = Directive::ToLeRadix {
         a: Expression::default(),
         b: vec![Witness(1u32), Witness(2u32), Witness(3u32), Witness(4u32)],
@@ -292,7 +236,7 @@ fn serialization_roundtrip() {
     };
 
     let directives =
-        vec![invert, quotient_none, quotient_predicate, truncate, odd_range, to_le_radix];
+        vec![invert, quotient_none, quotient_predicate, to_le_radix];
 
     for directive in directives {
         let (dir, got_dir) = read_write(directive);

--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -136,20 +136,6 @@ impl std::fmt::Display for Opcode {
                 write!(f, "DIR::INVERT ")?;
                 write!(f, "(_{}, out: _{}) ", x.witness_index(), r.witness_index())
             }
-            Opcode::Directive(Directive::Truncate { a, b, c, bit_size }) => {
-                write!(f, "DIR::TRUNCATE ")?;
-                write!(
-                    f,
-                    "(out: _{}, _{}, _{}, bit_size: {})",
-                    // TODO: Modify Noir to switch a and b
-                    b.witness_index(),
-                    a,
-                    // TODO: check why c was unused before, and check when directive is being processed
-                    // TODO: and if it is used
-                    c.witness_index(),
-                    bit_size
-                )
-            }
             Opcode::Directive(Directive::Quotient { a, b, q, r, predicate }) => {
                 write!(f, "DIR::QUOTIENT ")?;
                 if let Some(pred) = predicate {
@@ -162,18 +148,6 @@ impl std::fmt::Display for Opcode {
                     a,
                     q.witness_index(),
                     b,
-                    r.witness_index()
-                )
-            }
-            Opcode::Directive(Directive::OddRange { a, b, r, bit_size }) => {
-                write!(f, "DIR::ODDRANGE ")?;
-
-                write!(
-                    f,
-                    "(out: _{}, (_{}, bit_size: {}), _{})",
-                    a.witness_index(),
-                    b.witness_index(),
-                    bit_size,
                     r.witness_index()
                 )
             }

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -6,7 +6,7 @@ use acir::{
     FieldElement,
 };
 use num_bigint::BigUint;
-use num_traits::{One, Zero};
+use num_traits::{Zero};
 
 use crate::OpcodeResolutionError;
 
@@ -55,27 +55,6 @@ pub fn solve_directives(
 
             Ok(())
         }
-        Directive::Truncate { a, b, c, bit_size } => {
-            let val_a = get_value(a, initial_witness)?;
-            let pow: BigUint = BigUint::one() << bit_size;
-
-            let int_a = BigUint::from_bytes_be(&val_a.to_be_bytes());
-            let int_b: BigUint = &int_a % &pow;
-            let int_c: BigUint = (&int_a - &int_b) / &pow;
-
-            insert_witness(
-                *b,
-                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                initial_witness,
-            )?;
-            insert_witness(
-                *c,
-                FieldElement::from_be_bytes_reduce(&int_c.to_bytes_be()),
-                initial_witness,
-            )?;
-
-            Ok(())
-        }
         Directive::ToLeRadix { a, b, radix } => {
             let value_a = get_value(a, initial_witness)?;
             let big_integer = BigUint::from_bytes_be(&value_a.to_be_bytes());
@@ -99,31 +78,6 @@ pub fn solve_directives(
 
                 insert_value(witness, value, initial_witness)?
             }
-
-            Ok(())
-        }
-        Directive::OddRange { a, b, r, bit_size } => {
-            let val_a = witness_to_value(initial_witness, *a)?;
-            let int_a = BigUint::from_bytes_be(&val_a.to_be_bytes());
-            let pow: BigUint = BigUint::one() << (bit_size - 1);
-            if int_a >= (&pow << 1) {
-                return Err(OpcodeResolutionError::UnsatisfiedConstrain);
-            }
-
-            let bb = &int_a & &pow;
-            let int_r = &int_a - &bb;
-            let int_b = &bb >> (bit_size - 1);
-
-            insert_witness(
-                *b,
-                FieldElement::from_be_bytes_reduce(&int_b.to_bytes_be()),
-                initial_witness,
-            )?;
-            insert_witness(
-                *r,
-                FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
-                initial_witness,
-            )?;
 
             Ok(())
         }


### PR DESCRIPTION

# Description

## Summary of changes

Following noir PR#985, I remove the unused directives truncate and odd range. 


# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

