### PR TITLE
chore: add a checksum method for the constraint system

### DIFF
--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -18,6 +18,7 @@ acir.workspace = true
 stdlib.workspace = true
 
 sha2 = "0.9.3"
+crc32fast = "1.3.2"
 k256 = { version = "0.7.2", features = [
     "ecdsa",
     "ecdsa-core",

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -216,15 +216,15 @@ pub enum Language {
     PLONKCSat { width: usize },
 }
 
-pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
+pub fn hash_constraint_system(cs: &Circuit) -> u32 {
     let mut bytes = Vec::new();
     cs.write(&mut bytes).expect("could not serialize circuit");
 
-    use sha2::{digest::FixedOutput, Digest, Sha256};
-    let mut hasher = Sha256::new();
+    use crc32fast::Hasher;
+    let mut hasher = Hasher::new();
 
-    hasher.update(bytes);
-    hasher.finalize_fixed().into()
+    hasher.update(&bytes);
+    hasher.finalize()
 }
 
 #[deprecated(

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -216,7 +216,18 @@ pub enum Language {
     PLONKCSat { width: usize },
 }
 
-pub fn hash_constraint_system(cs: &Circuit) -> u32 {
+pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
+    let mut bytes = Vec::new();
+    cs.write(&mut bytes).expect("could not serialize circuit");
+
+    use sha2::{digest::FixedOutput, Digest, Sha256};
+    let mut hasher = Sha256::new();
+
+    hasher.update(bytes);
+    hasher.finalize_fixed().into()
+}
+
+pub fn checksum_constraint_system(cs: &Circuit) -> u32 {
     let mut bytes = Vec::new();
     cs.write(&mut bytes).expect("could not serialize circuit");
 


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Related to https://github.com/noir-lang/noir/issues/870

# Description

## Summary of changes

Move to a faster checksum https://github.com/srijs/rust-crc32fast

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

add `crc32fast = "1.3.2"` to acvm

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
