### PR TITLE
feat!(acir): Add RAM and ROM opcodes

### DIFF
--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -7,7 +7,7 @@ use crate::BlackBoxFunc;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Copy, Default)]
-pub struct BlockId(u32);
+pub struct BlockId(pub u32);
 
 /// Operation on a block
 /// We can either write or read at a block index

--- a/acvm/src/compiler.rs
+++ b/acvm/src/compiler.rs
@@ -11,7 +11,7 @@ use acir::{
 use indexmap::IndexMap;
 use optimizers::GeneralOptimizer;
 use thiserror::Error;
-use transformers::{CSatTransformer, FallbackTransformer, IsBlackBoxSupported, R1CSTransformer};
+use transformers::{CSatTransformer, FallbackTransformer, IsOpcodeSupported, R1CSTransformer};
 
 #[derive(PartialEq, Eq, Debug, Error)]
 pub enum CompileError {
@@ -22,14 +22,14 @@ pub enum CompileError {
 pub fn compile(
     acir: Circuit,
     np_language: Language,
-    is_black_box_supported: IsBlackBoxSupported,
+    is_opcode_supported: IsOpcodeSupported,
 ) -> Result<Circuit, CompileError> {
     // Instantiate the optimizer.
     // Currently the optimizer and reducer are one in the same
     // for CSAT
 
     // Fallback transformer pass
-    let acir = FallbackTransformer::transform(acir, is_black_box_supported)?;
+    let acir = FallbackTransformer::transform(acir, is_opcode_supported)?;
 
     // General optimizer pass
     let mut opcodes: Vec<Opcode> = Vec::new();

--- a/acvm/src/compiler/transformers/fallback.rs
+++ b/acvm/src/compiler/transformers/fallback.rs
@@ -6,7 +6,7 @@ use acir::{
 };
 
 // A predicate that returns true if the black box function is supported
-pub type IsBlackBoxSupported = fn(&BlackBoxFunc) -> bool;
+pub type IsOpcodeSupported = fn(&Opcode) -> bool;
 
 pub struct FallbackTransformer;
 
@@ -14,20 +14,20 @@ impl FallbackTransformer {
     //ACIR pass which replace unsupported opcodes using arithmetic fallback
     pub fn transform(
         acir: Circuit,
-        is_supported: IsBlackBoxSupported,
+        is_supported: IsOpcodeSupported,
     ) -> Result<Circuit, CompileError> {
         let mut acir_supported_opcodes = Vec::with_capacity(acir.opcodes.len());
 
         let mut witness_idx = acir.current_witness_index + 1;
 
         for opcode in acir.opcodes {
-            let bb_func_call = match &opcode {
+            match &opcode {
                 Opcode::Arithmetic(_)
                 | Opcode::Directive(_)
                 | Opcode::Block(_)
                 | Opcode::ROM(_)
                 | Opcode::RAM(_) => {
-                    // directive, arithmetic expression or block are handled by acvm
+                    // directive, arithmetic expression or blocks are handled by acvm
                     acir_supported_opcodes.push(opcode);
                     continue;
                 }
@@ -35,22 +35,21 @@ impl FallbackTransformer {
                     // We know it is an black box function. Now check if it is
                     // supported by the backend. If it is supported, then we can simply
                     // collect the opcode
-                    if is_supported(&bb_func_call.name) {
+                    if is_supported(&opcode) {
                         acir_supported_opcodes.push(opcode);
                         continue;
+                    } else {
+                        // If we get here then we know that this black box function is not supported
+                        // so we need to replace it with a version of the opcode which only uses arithmetic
+                        // expressions
+                        let (updated_witness_index, opcodes_fallback) =
+                            Self::opcode_fallback(bb_func_call, witness_idx)?;
+                        witness_idx = updated_witness_index;
+
+                        acir_supported_opcodes.extend(opcodes_fallback);
                     }
-                    bb_func_call
                 }
-            };
-
-            // If we get here then we know that this black box function is not supported
-            // so we need to replace it with a version of the opcode which only uses arithmetic
-            // expressions
-            let (updated_witness_index, opcodes_fallback) =
-                Self::opcode_fallback(bb_func_call, witness_idx)?;
-            witness_idx = updated_witness_index;
-
-            acir_supported_opcodes.extend(opcodes_fallback);
+            }
         }
 
         Ok(Circuit {

--- a/acvm/src/compiler/transformers/fallback.rs
+++ b/acvm/src/compiler/transformers/fallback.rs
@@ -22,7 +22,11 @@ impl FallbackTransformer {
 
         for opcode in acir.opcodes {
             let bb_func_call = match &opcode {
-                Opcode::Arithmetic(_) | Opcode::Directive(_) | Opcode::Block(_, _) => {
+                Opcode::Arithmetic(_)
+                | Opcode::Directive(_)
+                | Opcode::Block(_)
+                | Opcode::ROM(_)
+                | Opcode::RAM(_) => {
                     // directive, arithmetic expression or block are handled by acvm
                     acir_supported_opcodes.push(opcode);
                     continue;

--- a/acvm/src/compiler/transformers/mod.rs
+++ b/acvm/src/compiler/transformers/mod.rs
@@ -4,5 +4,5 @@ mod r1cs;
 
 pub use csat::CSatTransformer;
 pub use fallback::FallbackTransformer;
-pub use fallback::IsBlackBoxSupported;
+pub use fallback::IsOpcodeSupported;
 pub use r1cs::R1CSTransformer;

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -76,7 +76,9 @@ pub trait PartialWitnessGenerator {
                     Opcode::Directive(directive) => {
                         Self::solve_directives(initial_witness, directive)
                     }
-                    Opcode::Block(id, trace) => blocks.solve(*id, trace, initial_witness),
+                    Opcode::Block(block) | Opcode::ROM(block) | Opcode::RAM(block) => {
+                        blocks.solve(block.id, &block.trace, initial_witness)
+                    }
                 };
                 match resolution {
                     Ok(_) => {

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -215,12 +215,12 @@ pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
 // This is set to match the previous functionality that we had
 // Where we could deduce what black box functions were supported
 // by knowing the np complete language
-pub fn default_is_black_box_supported(
+pub fn default_is_opcode_supported(
     language: Language,
-) -> compiler::transformers::IsBlackBoxSupported {
+) -> compiler::transformers::IsOpcodeSupported {
     // R1CS does not support any of the black box functions by default.
     // The compiler will replace those that it can -- ie range, xor, and
-    fn r1cs_is_supported(_opcode: &BlackBoxFunc) -> bool {
+    fn r1cs_is_supported(_opcode: &Opcode) -> bool {
         false
     }
 
@@ -228,8 +228,12 @@ pub fn default_is_black_box_supported(
     // The ones which are not supported, the acvm compiler will
     // attempt to transform into supported gates. If these are also not available
     // then a compiler error will be emitted.
-    fn plonk_is_supported(opcode: &BlackBoxFunc) -> bool {
-        !matches!(opcode, BlackBoxFunc::AES)
+    fn plonk_is_supported(opcode: &Opcode) -> bool {
+        !matches!(
+            opcode,
+            Opcode::BlackBoxFuncCall(BlackBoxFuncCall { name: BlackBoxFunc::AES, .. })
+                | Opcode::Block(_)
+        )
     }
 
     match language {

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -233,18 +233,18 @@ pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
     note = "For backwards compatibility, this method allows you to derive _sensible_ defaults for black box function support based on the np language. \n Backends should simply specify what they support."
 )]
 // This is set to match the previous functionality that we had
-// Where we could deduce what black box functions were supported
+// Where we could deduce what opcodes were supported
 // by knowing the np complete language
 pub fn default_is_opcode_supported(
     language: Language,
 ) -> compiler::transformers::IsOpcodeSupported {
-    // R1CS does not support any of the black box functions by default.
+    // R1CS does not support any of the opcode except Arithmetic by default.
     // The compiler will replace those that it can -- ie range, xor, and
-    fn r1cs_is_supported(_opcode: &Opcode) -> bool {
-        false
+    fn r1cs_is_supported(opcode: &Opcode) -> bool {
+        matches!(opcode, Opcode::Arithmetic(_))
     }
 
-    // PLONK supports most of the black box functions by default
+    // PLONK supports most of the opcodes by default
     // The ones which are not supported, the acvm compiler will
     // attempt to transform into supported gates. If these are also not available
     // then a compiler error will be emitted.

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -41,17 +41,8 @@ struct BlockSolver {
 }
 
 impl BlockSolver {
-    fn insert_value(
-        &mut self,
-        index: u32,
-        value: FieldElement,
-    ) -> Result<(), OpcodeResolutionError> {
-        match self.block_value.insert(index, value) {
-            Some(existing_value) if value != existing_value => {
-                Err(OpcodeResolutionError::UnsatisfiedConstrain)
-            }
-            _ => Ok(()),
-        }
+    fn insert_value(&mut self, index: u32, value: FieldElement) {
+        self.block_value.insert(index, value);
     }
 
     fn get_value(&self, index: u32) -> Option<FieldElement> {
@@ -84,7 +75,7 @@ impl BlockSolver {
             let value = ArithmeticSolver::evaluate(&block_op.value, initial_witness);
             let value_witness = ArithmeticSolver::any_witness_from_expression(&value);
             if value.is_const() {
-                self.insert_value(index, value.q_c)?;
+                self.insert_value(index, value.q_c);
             } else if operation.is_zero() && value.is_linear() {
                 match ArithmeticSolver::solve_fan_in_term(&value, initial_witness) {
                     GateStatus::GateUnsolvable => return Err(missing_assignment(value_witness)),
@@ -93,7 +84,7 @@ impl BlockSolver {
                         insert_witness(w, (map_value - sum - value.q_c) / coef, initial_witness)?;
                     }
                     GateStatus::GateSatisfied(sum) => {
-                        self.insert_value(index, sum + value.q_c)?;
+                        self.insert_value(index, sum + value.q_c);
                     }
                 }
             } else {


### PR DESCRIPTION
# Description

## Summary of changes

Add ROM and RAM opcodes in order to support dynamic arrays for Aztec Backend.
The BLOCK opcode handles conditional writes by using an expression for the memory operation, but Barretenberg does not support this. We add RAM and ROM opcodes to help the backend to specify what it does support, so that noir can decide which opcode to use based on the array usage and the supported opcodes:

ROM: an initialisation phase with writes on constant indexes, then only read access
RAM: an initialisation phase with writes on constant indexes, then dynamic read or write access
BLOCK: the most flexible, if the backend supports it, it must enforce the correct constraints.

If the backend supports BLOCK, noir will use this opcode because it is more efficient,
if the backend supports RAM/ROM, then noir will use RAM/ROM opcode and generate conditional writes accordingly,
if the backend does not support any memory opcode, then noir will use the BLOCK opcode along with the memory consistency constraints.

# Checklist

- [ ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.
