### PR TITLE
fix(pwg): stall instead of fail for unassigned black box

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -165,7 +165,7 @@ pub trait PartialWitnessGenerator {
     ) -> Result<OpcodeResolution, OpcodeResolutionError>;
 
     // Check if all of the inputs to the function have assignments
-    // Returns the first missing asignment if any are missing
+    // Returns the first missing assignment if any are missing
     fn first_missing_assignment(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -88,11 +88,11 @@ pub trait PartialWitnessGenerator {
                 let resolution = match opcode {
                     Opcode::Arithmetic(expr) => ArithmeticSolver::solve(initial_witness, expr),
                     Opcode::BlackBoxFuncCall(bb_func) => {
-                        if let Some(unassigned_idx) =
-                            Self::first_missing_assignment(initial_witness, bb_func)
+                        if let Some(unassigned_witness) =
+                            Self::any_missing_assignment(initial_witness, bb_func)
                         {
                             Ok(OpcodeResolution::Stalled(OpcodeNotSolvable::MissingAssignment(
-                                unassigned_idx,
+                                unassigned_witness.0,
                             )))
                         } else {
                             Self::solve_black_box_function_call(initial_witness, bb_func)
@@ -166,15 +166,15 @@ pub trait PartialWitnessGenerator {
 
     // Check if all of the inputs to the function have assignments
     // Returns the first missing assignment if any are missing
-    fn first_missing_assignment(
+    fn any_missing_assignment(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         func_call: &BlackBoxFuncCall,
-    ) -> Option<u32> {
+    ) -> Option<Witness> {
         func_call.inputs.iter().find_map(|input| {
             if initial_witness.contains_key(&input.witness) {
                 None
             } else {
-                Some(input.witness.0)
+                Some(input.witness)
             }
         })
     }


### PR DESCRIPTION
inputs

# Related issue(s)

Resolves #153

# Description

## Summary of changes

Stall instead of fail when encountering black box function inputs.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.
