### PR TITLE
chore(acir)!: remove deprecated circuit serialization methods

### DIFF
--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -5,11 +5,8 @@ pub use opcodes::Opcode;
 
 use crate::native_types::Witness;
 use crate::serialization::{read_u32, write_u32};
-use rmp_serde;
 use serde::{Deserialize, Serialize};
 
-use flate2::bufread::{DeflateDecoder, DeflateEncoder};
-use flate2::Compression;
 use std::collections::BTreeSet;
 use std::io::prelude::*;
 
@@ -42,27 +39,6 @@ impl Circuit {
         let public_inputs =
             self.public_parameters.0.union(&self.return_values.0).cloned().collect();
         PublicInputs(public_inputs)
-    }
-
-    #[deprecated(
-        note = "we want to use a serialization strategy that is easy to implement in many languages (without ffi). use `read` instead"
-    )]
-    pub fn from_bytes(bytes: &[u8]) -> Circuit {
-        let mut deflater = DeflateDecoder::new(bytes);
-        let mut buf_d = Vec::new();
-        deflater.read_to_end(&mut buf_d).unwrap();
-        rmp_serde::from_slice(buf_d.as_slice()).unwrap()
-    }
-
-    #[deprecated(
-        note = "we want to use a serialization strategy that is easy to implement in many languages (without ffi).use `write` instead"
-    )]
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let buf = rmp_serde::to_vec(&self).unwrap();
-        let mut deflater = DeflateEncoder::new(buf.as_slice(), Compression::best());
-        let mut buf_c = Vec::new();
-        deflater.read_to_end(&mut buf_c).unwrap();
-        buf_c
     }
 
     pub fn write<W: Write>(&self, mut writer: W) -> std::io::Result<()> {
@@ -259,31 +235,6 @@ mod test {
         let json = serde_json::to_string_pretty(&circuit).unwrap();
 
         let deserialized = serde_json::from_str(&json).unwrap();
-        assert_eq!(circuit, deserialized);
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn test_to_byte() {
-        let circuit = Circuit {
-            current_witness_index: 0,
-            opcodes: vec![
-                Opcode::Arithmetic(crate::native_types::Expression {
-                    mul_terms: vec![],
-                    linear_combinations: vec![],
-                    q_c: FieldElement::from_hex("FFFF").unwrap(),
-                }),
-                range_opcode(),
-                and_opcode(),
-                oracle_opcode(),
-            ],
-            public_parameters: PublicInputs(BTreeSet::from_iter(vec![Witness(2)])),
-            return_values: PublicInputs(BTreeSet::from_iter(vec![Witness(2)])),
-        };
-
-        let bytes = circuit.to_bytes();
-
-        let deserialized = Circuit::from_bytes(bytes.as_slice());
         assert_eq!(circuit, deserialized);
     }
 }


### PR DESCRIPTION
# Description

## Summary of changes

This PR removes the deprecated `Circuit::to_bytes` and `Circuit::from_bytes` methods which were deprecated in [0.2.1](https://github.com/noir-lang/acvm/commit/054ffdd8664f59bc35575b23e44d03f8db87b1e9)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
