### PR TITLE
feat(acvm)!: make `Backend` trait object safe

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -325,7 +325,8 @@ mod test {
     };
 
     use crate::{
-        pwg::block::Blocks, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
+        pwg::block::Blocks, Backend, OpcodeResolution, OpcodeResolutionError,
+        PartialWitnessGenerator,
     };
 
     struct StubbedPwg;
@@ -407,5 +408,13 @@ mod test {
             .expect("should be solvable");
         assert!(unsolved_opcodes.is_empty(), "should be fully solved");
         assert!(unresolved_oracles.is_empty(), "should have no unresolved oracles");
+    }
+
+    #[test]
+    fn test_backend_object_safety() {
+        // This test doesn't do anything at runtime.
+        // We just want to ensure that the `Backend` trait is object safe and this test will refuse to compile
+        // if this property is broken.
+        fn check_object_safety(_backend: Box<dyn Backend>) {}
     }
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #179 

# Description

## Summary of changes

I've spun out `PartialWitnessGenerator::any_missing_assignment` and `PartialWitnessGenerator::solve_directives` into standalone functions and added a `&self` parameter to  `PartialWitnessGenerator::solve_black_box_function_call`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

I've also added a test to ensure that the `Backend` trait remains object safe (I couldn't find any lint, etc. which would enforce this so I've just attempted to pass a trait object to a function as this will fail to compile should `Backend` not be object safe.

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
