### PR TITLE
chore(acvm)!: Remove `eth_contract_from_cs` from SmartContract trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -182,16 +182,6 @@ pub trait PartialWitnessGenerator {
 pub trait SmartContract {
     // TODO: Allow a backend to support multiple smart contract platforms
 
-    /// Takes an ACIR circuit, the number of witnesses and the number of public inputs
-    /// Then returns an Ethereum smart contract
-    ///
-    /// XXX: This will be deprecated in future releases for the above method.
-    /// This deprecation may happen in two stages:
-    /// The first stage will remove `num_witnesses` and `num_public_inputs` parameters.
-    /// If we cannot avoid `num_witnesses`, it can be added into the Circuit struct.
-    #[deprecated]
-    fn eth_contract_from_cs(&self, circuit: Circuit) -> String;
-
     /// Returns an Ethereum smart contract to verify proofs against a given verification key.
     fn eth_contract_from_vk(&self, verification_key: &[u8]) -> String;
 }


### PR DESCRIPTION
# Related issue(s)

Resolves #184

# Description

This removes the deprecated `eth_contract_from_cs` function from the SmartContract trait. With https://github.com/noir-lang/aztec_backend/pull/84, we've made the switch to using `eth_contract_from_vk` to generate the solidity contract so we don't need to keep these around.

## Summary of changes

Removed the deprecated function.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
