### PR TITLE
chore!: organise operator implementations for `Expression`

### DIFF
--- a/acir/src/native_types/expression/operators.rs
+++ b/acir/src/native_types/expression/operators.rs
@@ -1,0 +1,152 @@
+use crate::native_types::Witness;
+use acir_field::FieldElement;
+use std::ops::{Add, Mul, Neg, Sub};
+
+use super::Expression;
+
+// Negation
+
+impl Neg for &Expression {
+    type Output = Expression;
+    fn neg(self) -> Self::Output {
+        // XXX(med) : Implement an efficient way to do this
+
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (-*q_m, *w_l, *w_r)).collect();
+
+        let linear_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_k, w_k)| (-*q_k, *w_k)).collect();
+        let q_c = -self.q_c;
+
+        Expression { mul_terms, linear_combinations, q_c }
+    }
+}
+
+// FieldElement
+
+impl Add<FieldElement> for Expression {
+    type Output = Expression;
+    fn add(self, rhs: FieldElement) -> Self::Output {
+        // Increase the constant
+        let q_c = self.q_c + rhs;
+
+        Expression { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
+    }
+}
+
+impl Add<Expression> for FieldElement {
+    type Output = Expression;
+    #[inline]
+    fn add(self, rhs: Expression) -> Self::Output {
+        rhs + self
+    }
+}
+
+impl Sub<FieldElement> for Expression {
+    type Output = Expression;
+    fn sub(self, rhs: FieldElement) -> Self::Output {
+        // Increase the constant
+        let q_c = self.q_c - rhs;
+
+        Expression { mul_terms: self.mul_terms, q_c, linear_combinations: self.linear_combinations }
+    }
+}
+
+impl Sub<Expression> for FieldElement {
+    type Output = Expression;
+    #[inline]
+    fn sub(self, rhs: Expression) -> Self::Output {
+        rhs - self
+    }
+}
+
+impl Mul<FieldElement> for &Expression {
+    type Output = Expression;
+    fn mul(self, rhs: FieldElement) -> Self::Output {
+        // Scale the mul terms
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().map(|(q_m, w_l, w_r)| (*q_m * rhs, *w_l, *w_r)).collect();
+
+        // Scale the linear combinations terms
+        let lin_combinations: Vec<_> =
+            self.linear_combinations.iter().map(|(q_l, w_l)| (*q_l * rhs, *w_l)).collect();
+
+        // Scale the constant
+        let q_c = self.q_c * rhs;
+
+        Expression { mul_terms, q_c, linear_combinations: lin_combinations }
+    }
+}
+
+impl Mul<&Expression> for FieldElement {
+    type Output = Expression;
+    #[inline]
+    fn mul(self, rhs: &Expression) -> Self::Output {
+        rhs * self
+    }
+}
+
+// Witness
+
+impl Add<Witness> for &Expression {
+    type Output = Expression;
+    fn add(self, rhs: Witness) -> Expression {
+        self + &Expression::from(rhs)
+    }
+}
+
+impl Add<&Expression> for Witness {
+    type Output = Expression;
+    #[inline]
+    fn add(self, rhs: &Expression) -> Expression {
+        rhs + self
+    }
+}
+
+impl Sub<Witness> for &Expression {
+    type Output = Expression;
+    fn sub(self, rhs: Witness) -> Expression {
+        self - &Expression::from(rhs)
+    }
+}
+
+impl Sub<&Expression> for Witness {
+    type Output = Expression;
+    #[inline]
+    fn sub(self, rhs: &Expression) -> Expression {
+        rhs - self
+    }
+}
+
+// Mul<Witness> is not implemented as this could result in degree 3 terms.
+
+// Expression
+
+impl Add<&Expression> for &Expression {
+    type Output = Expression;
+    fn add(self, rhs: &Expression) -> Expression {
+        // XXX(med) : Implement an efficient way to do this
+
+        let mul_terms: Vec<_> =
+            self.mul_terms.iter().cloned().chain(rhs.mul_terms.iter().cloned()).collect();
+
+        let linear_combinations: Vec<_> = self
+            .linear_combinations
+            .iter()
+            .cloned()
+            .chain(rhs.linear_combinations.iter().cloned())
+            .collect();
+        let q_c = self.q_c + rhs.q_c;
+
+        Expression { mul_terms, linear_combinations, q_c }
+    }
+}
+
+impl Sub<&Expression> for &Expression {
+    type Output = Expression;
+    fn sub(self, rhs: &Expression) -> Expression {
+        self + &-rhs
+    }
+}
+
+// Mul<Expression> is not implemented as this could result in degree 3+ terms.

--- a/acir/src/native_types/expression/ordering.rs
+++ b/acir/src/native_types/expression/ordering.rs
@@ -1,0 +1,99 @@
+use crate::native_types::Witness;
+use std::cmp::Ordering;
+
+use super::Expression;
+
+// TODO: It's undecided whether `Expression` should implement `Ord/PartialOrd`.
+// This is currently used in ACVM in the compiler.
+
+impl Ord for Expression {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let mut i1 = self.get_max_idx();
+        let mut i2 = other.get_max_idx();
+        let mut result = Ordering::Equal;
+        while result == Ordering::Equal {
+            let m1 = self.get_max_term(&mut i1);
+            let m2 = other.get_max_term(&mut i2);
+            if m1.is_none() && m2.is_none() {
+                return Ordering::Equal;
+            }
+            result = Expression::cmp_max(m1, m2);
+        }
+        result
+    }
+}
+
+impl PartialOrd for Expression {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+struct WitnessIdx {
+    linear: usize,
+    mul: usize,
+    second_term: bool,
+}
+
+impl Expression {
+    fn get_max_idx(&self) -> WitnessIdx {
+        WitnessIdx {
+            linear: self.linear_combinations.len(),
+            mul: self.mul_terms.len(),
+            second_term: true,
+        }
+    }
+
+    /// Returns the maximum witness at the provided position, and decrement the position.
+    ///
+    /// This function assumes the gate is sorted
+    fn get_max_term(&self, idx: &mut WitnessIdx) -> Option<Witness> {
+        if idx.linear > 0 {
+            if idx.mul > 0 {
+                let mul_term = if idx.second_term {
+                    self.mul_terms[idx.mul - 1].2
+                } else {
+                    self.mul_terms[idx.mul - 1].1
+                };
+                if self.linear_combinations[idx.linear - 1].1 > mul_term {
+                    idx.linear -= 1;
+                    Some(self.linear_combinations[idx.linear].1)
+                } else {
+                    if idx.second_term {
+                        idx.second_term = false;
+                    } else {
+                        idx.mul -= 1;
+                    }
+                    Some(mul_term)
+                }
+            } else {
+                idx.linear -= 1;
+                Some(self.linear_combinations[idx.linear].1)
+            }
+        } else if idx.mul > 0 {
+            if idx.second_term {
+                idx.second_term = false;
+                Some(self.mul_terms[idx.mul - 1].2)
+            } else {
+                idx.mul -= 1;
+                Some(self.mul_terms[idx.mul].1)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn cmp_max(m1: Option<Witness>, m2: Option<Witness>) -> Ordering {
+        if let Some(m1) = m1 {
+            if let Some(m2) = m2 {
+                m1.cmp(&m2)
+            } else {
+                Ordering::Greater
+            }
+        } else if m2.is_some() {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
+    }
+}

--- a/acir/src/native_types/mod.rs
+++ b/acir/src/native_types/mod.rs
@@ -1,5 +1,5 @@
-mod arithmetic;
+mod expression;
 mod witness;
 
-pub use arithmetic::Expression;
+pub use expression::Expression;
 pub use witness::Witness;

--- a/acvm/src/compiler/transformers/fallback.rs
+++ b/acvm/src/compiler/transformers/fallback.rs
@@ -70,8 +70,8 @@ impl FallbackTransformer {
             BlackBoxFunc::AND => {
                 let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
                 stdlib::fallback::and(
-                    Expression::from(&lhs),
-                    Expression::from(&rhs),
+                    Expression::from(lhs),
+                    Expression::from(rhs),
                     result,
                     num_bits,
                     current_witness_idx,
@@ -80,8 +80,8 @@ impl FallbackTransformer {
             BlackBoxFunc::XOR => {
                 let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
                 stdlib::fallback::xor(
-                    Expression::from(&lhs),
-                    Expression::from(&rhs),
+                    Expression::from(lhs),
+                    Expression::from(rhs),
                     result,
                     num_bits,
                     current_witness_idx,
@@ -93,7 +93,7 @@ impl FallbackTransformer {
                 let input = &gc.inputs[0];
                 // Note there are no outputs because range produces no outputs
                 stdlib::fallback::range(
-                    Expression::from(&input.witness),
+                    Expression::from(input.witness),
                     input.num_bits,
                     current_witness_idx,
                 )

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -141,24 +141,24 @@ mod test {
         let mut trace = vec![MemOp {
             operation: Expression::one(),
             index: Expression::from_field(index),
-            value: Expression::from(&Witness(1)),
+            value: Expression::from(Witness(1)),
         }];
         index += FieldElement::one();
         trace.push(MemOp {
             operation: Expression::one(),
             index: Expression::from_field(index),
-            value: Expression::from(&Witness(2)),
+            value: Expression::from(Witness(2)),
         });
         index += FieldElement::one();
         trace.push(MemOp {
             operation: Expression::one(),
             index: Expression::from_field(index),
-            value: Expression::from(&Witness(3)),
+            value: Expression::from(Witness(3)),
         });
         trace.push(MemOp {
             operation: Expression::zero(),
             index: Expression::one(),
-            value: Expression::from(&Witness(4)),
+            value: Expression::from(Witness(4)),
         });
         let id = BlockId::default();
         let mut initial_witness = BTreeMap::new();

--- a/stdlib/src/fallback.rs
+++ b/stdlib/src/fallback.rs
@@ -48,7 +48,7 @@ pub(crate) fn bit_decomposition(
     // of the input and each bit is actually a bit
     let mut binary_exprs = Vec::new();
     let mut bit_decomp_constraint = gate;
-    let mut two_pow = FieldElement::one();
+    let mut two_pow: FieldElement = FieldElement::one();
     let two = FieldElement::from(2_i128);
     for &bit in &bit_vector {
         // Bit constraint to ensure each bit is a zero or one; bit^2 - bit = 0


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

The disorganised approach we have to implementing various traits on `Expression` has been bugging me. We've got a jumble of `From`s, maths operators and sorting operators all in the same file. This means that we're missing a few operator definitions which we'd want but it's not obvious that they're missing because there's not a defined order for them.

This PR takes `arithmetic.rs` and renames it to `expression.rs`, we then break this into three files:
- `mod.rs` which contains the bulk of the definition of `Expression` along with the main `impl`.
- `operators.rs` which defines `Add, Mul, Neg, Sub` on `Expression` against itself, `Witness` and `FieldElement`.
- `ordering.rs` which contains the logic necessary to implement `Ord/PartialOrd`

I've also made the `Add, Mul, Sub` operators all commutative.

One thing to note is that I've removed the from/operator implementations for `&FieldElement` and `&Witness` in favour of `FieldElement` and `Witness`. This is to match the fact that we only define arithmetic operators for `FieldElements` and not  `&FieldElement` in `acir_field` and `Witness` is a glorified `u32` so the benefits of passing by reference is going to be negligible or negative.

Breaking change as we'll likely have to remove some `&` to account for this.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
