### PR TITLE
fix: Switch Brillig Store and Load `index` to RegisterMemIndex

### DIFF
--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -10,9 +10,21 @@ use acir_field::FieldElement;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub enum JabberingIn {
+    Simple(Expression),
+    Array(u32, Vec<Expression>),
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
+pub enum JabberingOut {
+    Simple(Witness),
+    Array(Vec<Witness>),
+}
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Debug)]
 pub struct Brillig {
-    pub inputs: Vec<Expression>,
-    pub outputs: Vec<Witness>,
+    pub inputs: Vec<JabberingIn>,
+    pub outputs: Vec<JabberingOut>,
     pub bytecode: Vec<brillig_bytecode::Opcode>,
     /// Predicate of the Brillig execution - indicates if it should be skipped
     pub predicate: Option<Expression>,

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -352,7 +352,7 @@ mod test {
         brillig_bytecode::{BinaryOp, Comparison, RegisterIndex, RegisterMemIndex, Typ},
         circuit::{
             directives::Directive,
-            opcodes::{BlackBoxFuncCall, Brillig, OracleData},
+            opcodes::{BlackBoxFuncCall, Brillig, JabberingIn, JabberingOut, OracleData},
             Opcode,
         },
         native_types::{Expression, Witness},
@@ -491,14 +491,19 @@ mod test {
 
         let brillig_opcode = Opcode::Brillig(Brillig {
             inputs: vec![
-                Expression {
+                JabberingIn::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
-                },
-                Expression::default(),
+                }),
+                JabberingIn::Simple(Expression::default()),
             ],
-            outputs: vec![w_x_plus_y, w_oracle, w_equal_res, w_lt_res],
+            outputs: vec![
+                JabberingOut::Simple(w_x_plus_y),
+                JabberingOut::Simple(w_oracle),
+                JabberingOut::Simple(w_equal_res),
+                JabberingOut::Simple(w_lt_res),
+            ],
             bytecode: brillig_bytecode.clone(),
             predicate: None,
         });
@@ -550,18 +555,23 @@ mod test {
 
         let mut next_opcodes_for_solving = vec![Opcode::Brillig(Brillig {
             inputs: vec![
-                Expression {
+                JabberingIn::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
-                },
-                Expression::default(),
+                }),
+                JabberingIn::Simple(Expression::default()),
                 // These are the Brillig binary op results
                 // We include the register values here so that they are part of the witness
-                Expression::default(),
-                Expression::default(),
+                JabberingIn::Simple(Expression::default()),
+                JabberingIn::Simple(Expression::default()),
             ],
-            outputs: vec![w_x_plus_y, w_oracle, w_equal_res, w_lt_res],
+            outputs: vec![
+                JabberingOut::Simple(w_x_plus_y),
+                JabberingOut::Simple(w_oracle),
+                JabberingOut::Simple(w_equal_res),
+                JabberingOut::Simple(w_lt_res),
+            ],
             bytecode: new_brillig_bytecode,
             predicate: None,
         })];
@@ -624,14 +634,19 @@ mod test {
 
         let brillig_opcode = Opcode::Brillig(Brillig {
             inputs: vec![
-                Expression {
+                JabberingIn::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
-                },
-                Expression::default(),
+                }),
+                JabberingIn::Simple(Expression::default()),
             ],
-            outputs: vec![w_x_plus_y, w_oracle, w_equal_res, w_lt_res],
+            outputs: vec![
+                JabberingOut::Simple(w_x_plus_y),
+                JabberingOut::Simple(w_oracle),
+                JabberingOut::Simple(w_equal_res),
+                JabberingOut::Simple(w_lt_res),
+            ],
             bytecode: brillig_bytecode.clone(),
             predicate: Some(Expression::default()),
         });

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -352,7 +352,7 @@ mod test {
         brillig_bytecode::{BinaryOp, Comparison, RegisterIndex, RegisterMemIndex, Typ},
         circuit::{
             directives::Directive,
-            opcodes::{BlackBoxFuncCall, Brillig, JabberingIn, JabberingOut, OracleData},
+            opcodes::{BlackBoxFuncCall, Brillig, BrilligInputs, BrilligOutputs, OracleData},
             Opcode,
         },
         native_types::{Expression, Witness},
@@ -491,18 +491,18 @@ mod test {
 
         let brillig_opcode = Opcode::Brillig(Brillig {
             inputs: vec![
-                JabberingIn::Simple(Expression {
+                BrilligInputs::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
                 }),
-                JabberingIn::Simple(Expression::default()),
+                BrilligInputs::Simple(Expression::default()),
             ],
             outputs: vec![
-                JabberingOut::Simple(w_x_plus_y),
-                JabberingOut::Simple(w_oracle),
-                JabberingOut::Simple(w_equal_res),
-                JabberingOut::Simple(w_lt_res),
+                BrilligOutputs::Simple(w_x_plus_y),
+                BrilligOutputs::Simple(w_oracle),
+                BrilligOutputs::Simple(w_equal_res),
+                BrilligOutputs::Simple(w_lt_res),
             ],
             bytecode: brillig_bytecode.clone(),
             predicate: None,
@@ -555,22 +555,22 @@ mod test {
 
         let mut next_opcodes_for_solving = vec![Opcode::Brillig(Brillig {
             inputs: vec![
-                JabberingIn::Simple(Expression {
+                BrilligInputs::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
                 }),
-                JabberingIn::Simple(Expression::default()),
+                BrilligInputs::Simple(Expression::default()),
                 // These are the Brillig binary op results
                 // We include the register values here so that they are part of the witness
-                JabberingIn::Simple(Expression::default()),
-                JabberingIn::Simple(Expression::default()),
+                BrilligInputs::Simple(Expression::default()),
+                BrilligInputs::Simple(Expression::default()),
             ],
             outputs: vec![
-                JabberingOut::Simple(w_x_plus_y),
-                JabberingOut::Simple(w_oracle),
-                JabberingOut::Simple(w_equal_res),
-                JabberingOut::Simple(w_lt_res),
+                BrilligOutputs::Simple(w_x_plus_y),
+                BrilligOutputs::Simple(w_oracle),
+                BrilligOutputs::Simple(w_equal_res),
+                BrilligOutputs::Simple(w_lt_res),
             ],
             bytecode: new_brillig_bytecode,
             predicate: None,
@@ -634,18 +634,18 @@ mod test {
 
         let brillig_opcode = Opcode::Brillig(Brillig {
             inputs: vec![
-                JabberingIn::Simple(Expression {
+                BrilligInputs::Simple(Expression {
                     mul_terms: vec![],
                     linear_combinations: vec![(fe_1, w_x), (fe_1, w_y)],
                     q_c: fe_0,
                 }),
-                JabberingIn::Simple(Expression::default()),
+                BrilligInputs::Simple(Expression::default()),
             ],
             outputs: vec![
-                JabberingOut::Simple(w_x_plus_y),
-                JabberingOut::Simple(w_oracle),
-                JabberingOut::Simple(w_equal_res),
-                JabberingOut::Simple(w_lt_res),
+                BrilligOutputs::Simple(w_x_plus_y),
+                BrilligOutputs::Simple(w_oracle),
+                BrilligOutputs::Simple(w_equal_res),
+                BrilligOutputs::Simple(w_lt_res),
             ],
             bytecode: brillig_bytecode.clone(),
             predicate: Some(Expression::default()),

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -1,12 +1,11 @@
 use std::collections::BTreeMap;
 
 use acir::{
-    brillig_bytecode::{Opcode, OracleData, Registers, Typ, VMStatus, Value, VM},
+    brillig_bytecode::{Opcode, OracleData, Registers, Typ, VMOutputState, VMStatus, Value, VM},
     circuit::opcodes::{Brillig, JabberingIn, JabberingOut},
     native_types::Witness,
     FieldElement,
 };
-use k256::elliptic_curve::Field;
 
 use crate::{
     pwg::arithmetic::ArithmeticSolver, OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError,
@@ -43,7 +42,6 @@ impl BrilligSolver {
                         insert_witness(*witness, FieldElement::zero(), initial_witness)?
                     }
                     JabberingOut::Array(witness_arr) => {
-                        //todo, the
                         for w in witness_arr {
                             insert_witness(*w, FieldElement::zero(), initial_witness)?
                         }
@@ -55,10 +53,10 @@ impl BrilligSolver {
 
         // Set input values
         let mut input_register_values: Vec<Value> = Vec::new();
-        let mut input_memory: BTreeMap<u32, Vec<Value>> = BTreeMap::new();
+        let mut input_memory: BTreeMap<Value, Vec<Value>> = BTreeMap::new();
         for input in &brillig.inputs {
             match input {
-                JabberingIn::Simple(epxr) => {
+                JabberingIn::Simple(expr) => {
                     // TODO: switch this to `get_value` and map the err
                     let solve = ArithmeticSolver::evaluate(expr, initial_witness);
                     if let Some(value) = solve.to_const() {
@@ -69,12 +67,12 @@ impl BrilligSolver {
                 }
                 JabberingIn::Array(id, expr_arr) => {
                     let id_as_value: Value =
-                        Value { typ: Typ::ArrayId, inner: FieldElement::from(id as u128) };
+                        Value { typ: Typ::ArrayId, inner: FieldElement::from(*id as u128) };
                     // Push value of the array id as a register
                     input_register_values.push(id_as_value.into());
 
-                    let continue_eval = true;
-                    let array_heap: Vec<Value> = Vec::new();
+                    let mut continue_eval = true;
+                    let mut array_heap: Vec<Value> = Vec::new();
                     for expr in expr_arr {
                         let solve = ArithmeticSolver::evaluate(expr, initial_witness);
                         if let Some(value) = solve.to_const() {
@@ -84,7 +82,7 @@ impl BrilligSolver {
                             break;
                         }
                     }
-                    input_memory.insert(id, array_heap);
+                    input_memory.insert(id_as_value, array_heap);
 
                     if !continue_eval {
                         break;
@@ -94,22 +92,26 @@ impl BrilligSolver {
         }
 
         if input_register_values.len() != brillig.inputs.len() {
+            let jabber_input =
+                brillig.inputs.last().expect("Infallible: cannot reach this point if no inputs");
+            let expr = match jabber_input {
+                JabberingIn::Simple(expr) => expr,
+                JabberingIn::Array(_, expr_arr) => {
+                    expr_arr.last().expect("Infallible: cannot reach this point if no inputs")
+                }
+            };
             return Ok(OpcodeResolution::Stalled(OpcodeNotSolvable::ExpressionHasTooManyUnknowns(
-                brillig
-                    .inputs
-                    .last()
-                    .expect("Infallible: cannot reach this point if no inputs")
-                    .clone(),
+                expr.clone(),
             )));
         }
 
         let input_registers = Registers { inner: input_register_values };
         let vm = VM::new(input_registers, input_memory, brillig.bytecode.clone());
 
-        let (output_registers, status, pc) = vm.process_opcodes();
+        let VMOutputState { registers, program_counter, status, memory } = vm.process_opcodes();
 
         if status == VMStatus::OracleWait {
-            let current_opcode = &brillig.bytecode[pc];
+            let current_opcode = &brillig.bytecode[program_counter];
             let mut data = match current_opcode.clone() {
                 Opcode::Oracle(data) => data,
                 _ => {
@@ -124,28 +126,28 @@ impl BrilligSolver {
                 .clone()
                 .inputs
                 .into_iter()
-                .map(|register_mem_index| output_registers.get(register_mem_index).inner)
+                .map(|register_mem_index| registers.get(register_mem_index).inner)
                 .collect::<Vec<_>>();
             data.input_values = input_values;
 
             return Ok(OpcodeResolution::InProgressBrillig(OracleWaitInfo {
                 data: data.clone(),
-                program_counter: pc,
+                program_counter,
             }));
         }
 
-        let output_register_values: Vec<FieldElement> = output_registers
-            .clone()
-            .inner
-            .into_iter()
-            .map(|v| match v.typ {
-                Typ::ArrayId => vm.load_array(&v),
-                _ => v.inner,
-            })
-            .collect::<Vec<_>>();
-
-        for (witness, value) in brillig.outputs.iter().zip(output_register_values) {
-            insert_witness(*witness, value, initial_witness)?;
+        for (output, register_value) in brillig.outputs.iter().zip(registers) {
+            match output {
+                JabberingOut::Simple(witness) => {
+                    insert_witness(*witness, register_value.inner, initial_witness)?
+                }
+                JabberingOut::Array(witness_arr) => {
+                    let array = memory[&register_value].clone();
+                    for (witness, value) in witness_arr.iter().zip(array) {
+                        insert_witness(*witness, value.inner, initial_witness)?;
+                    }
+                }
+            }
         }
 
         Ok(OpcodeResolution::Solved)

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -66,8 +66,10 @@ impl BrilligSolver {
                     }
                 }
                 JabberingIn::Array(id, expr_arr) => {
-                    let id_as_value: Value =
-                        Value { typ: Typ::ArrayId, inner: FieldElement::from(*id as u128) };
+                    let id_as_value: Value = Value {
+                        typ: Typ::Unsigned { bit_size: 32 },
+                        inner: FieldElement::from(*id as u128),
+                    };
                     // Push value of the array id as a register
                     input_register_values.push(id_as_value.into());
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -220,81 +220,6 @@ pub struct VMOutputState {
 }
 
 #[test]
-fn load_opcode() {
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(0u128),
-        Value::from(6u128),
-        Value::from(0u128),
-    ]);
-
-    let equal_cmp_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let jump_opcode = Opcode::JMP { destination: 3 };
-
-    let jump_if_opcode =
-        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 10 };
-
-    let load_opcode = Opcode::Load {
-        destination: RegisterMemIndex::Register(RegisterIndex(4)),
-        array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
-        index: 1,
-    };
-
-    let mem_equal_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(4)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(5)),
-        result: RegisterIndex(6),
-    };
-
-    let mut initial_memory = BTreeMap::new();
-    initial_memory.insert(Value::from(5u128), vec![Value::from(5u128), Value::from(6u128)]);
-
-    let mut vm = VM::new(
-        input_registers,
-        initial_memory,
-        vec![equal_cmp_opcode, load_opcode, jump_opcode, mem_equal_opcode, jump_if_opcode],
-    );
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(4)));
-    assert_eq!(output_cmp_value, Value::from(6u128));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(6)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    vm.finish();
-}
-
-#[test]
 fn add_single_step_smoke() {
     // Load values into registers and initialize the registers that
     // will be used during bytecode processing
@@ -330,7 +255,7 @@ fn add_single_step_smoke() {
 }
 
 #[test]
-fn test_jmpif_opcode() {
+fn jmpif_opcode() {
     let input_registers =
         Registers::load(vec![Value::from(2u128), Value::from(2u128), Value::from(0u128)]);
 
@@ -369,7 +294,7 @@ fn test_jmpif_opcode() {
 }
 
 #[test]
-fn test_jmpifnot_opcode() {
+fn jmpifnot_opcode() {
     let input_registers =
         Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(0u128)]);
 
@@ -426,7 +351,7 @@ fn test_jmpifnot_opcode() {
 }
 
 #[test]
-fn test_mov_opcode() {
+fn mov_opcode() {
     let input_registers =
         Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(3u128)]);
 
@@ -440,7 +365,7 @@ fn test_mov_opcode() {
     let status = vm.process_opcode();
     assert_eq!(status, VMStatus::Halted);
 
-    let VMOutputState { registers, status, .. } = vm.finish();
+    let VMOutputState { registers, .. } = vm.finish();
 
     let destination_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
     assert_eq!(destination_value, Value::from(1u128));
@@ -450,7 +375,7 @@ fn test_mov_opcode() {
 }
 
 #[test]
-fn test_cmp_binary_ops() {
+fn cmp_binary_ops() {
     let input_registers = Registers::load(vec![
         Value::from(2u128),
         Value::from(2u128),
@@ -520,6 +445,154 @@ fn test_cmp_binary_ops() {
 
     let lte_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
     assert_eq!(lte_value, Value::from(true));
+
+    vm.finish();
+}
+
+#[test]
+fn load_opcode() {
+    let input_registers = Registers::load(vec![
+        Value::from(2u128),
+        Value::from(2u128),
+        Value::from(0u128),
+        Value::from(5u128),
+        Value::from(0u128),
+        Value::from(6u128),
+        Value::from(0u128),
+    ]);
+
+    let equal_cmp_opcode = Opcode::BinaryOp {
+        result_type: Typ::Field,
+        op: BinaryOp::Cmp(Comparison::Eq),
+        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+        result: RegisterIndex(2),
+    };
+
+    let jump_opcode = Opcode::JMP { destination: 3 };
+
+    let jump_if_opcode =
+        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 10 };
+
+    let load_opcode = Opcode::Load {
+        destination: RegisterMemIndex::Register(RegisterIndex(4)),
+        array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
+        index: 1,
+    };
+
+    let mem_equal_opcode = Opcode::BinaryOp {
+        result_type: Typ::Field,
+        op: BinaryOp::Cmp(Comparison::Eq),
+        lhs: RegisterMemIndex::Register(RegisterIndex(4)),
+        rhs: RegisterMemIndex::Register(RegisterIndex(5)),
+        result: RegisterIndex(6),
+    };
+
+    let mut initial_memory = BTreeMap::new();
+    initial_memory.insert(Value::from(5u128), vec![Value::from(5u128), Value::from(6u128)]);
+
+    let mut vm = VM::new(
+        input_registers,
+        initial_memory,
+        vec![equal_cmp_opcode, load_opcode, jump_opcode, mem_equal_opcode, jump_if_opcode],
+    );
+
+    // equal_cmp_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+    assert_eq!(output_cmp_value, Value::from(true));
+
+    // load_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(4)));
+    assert_eq!(output_cmp_value, Value::from(6u128));
+
+    // jump_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    // mem_equal_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(6)));
+    assert_eq!(output_cmp_value, Value::from(true));
+
+    // jump_if_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::Halted);
+
+    vm.finish();
+}
+
+#[test]
+fn store_opcode() {
+    let input_registers = Registers::load(vec![
+        Value::from(2u128),
+        Value::from(2u128),
+        Value::from(0u128),
+        Value::from(5u128),
+        Value::from(0u128),
+        Value::from(6u128),
+        Value::from(0u128),
+    ]);
+
+    let equal_cmp_opcode = Opcode::BinaryOp {
+        result_type: Typ::Field,
+        op: BinaryOp::Cmp(Comparison::Eq),
+        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+        result: RegisterIndex(2),
+    };
+
+    let jump_opcode = Opcode::JMP { destination: 3 };
+
+    let jump_if_opcode =
+        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 10 };
+
+    let store_opcode = Opcode::Store {
+        source: RegisterMemIndex::Register(RegisterIndex(2)),
+        array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
+        index: 2,
+    };
+
+    let mut initial_memory = BTreeMap::new();
+    initial_memory.insert(
+        Value::from(5u128),
+        vec![Value::from(5u128), Value::from(6u128), Value::from(0u128)],
+    );
+
+    let mut vm = VM::new(
+        input_registers,
+        initial_memory,
+        vec![equal_cmp_opcode, store_opcode, jump_opcode, jump_if_opcode],
+    );
+
+    // equal_cmp_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+    assert_eq!(output_cmp_value, Value::from(true));
+
+    // store_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    let mem_array = vm.memory[&Value::from(5u128)].clone();
+    assert_eq!(mem_array[2], Value::from(true));
+
+    // jump_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::InProgress);
+
+    // jump_if_opcode
+    let status = vm.process_opcode();
+    assert_eq!(status, VMStatus::Halted);
 
     vm.finish();
 }

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -150,7 +150,12 @@ impl VM {
                 let array = &self.memory[&array_id];
                 match destination {
                     RegisterMemIndex::Register(dest_index) => {
-                        self.registers.set(*dest_index, array.memory_map[index]);
+                        let index_value = self.registers.get(*index);
+                        let index_usize = usize::try_from(
+                            index_value.inner.try_to_u64().expect("register does not fit into u64"),
+                        )
+                        .expect("register does not fit into usize");
+                        self.registers.set(*dest_index, array.memory_map[&index_usize]);
                     }
                     _ => return VMStatus::Failure, // TODO: add variants to VMStatus::Failure for more informed failures
                 }
@@ -160,7 +165,13 @@ impl VM {
                 let source_value = self.registers.get(*source);
                 let array_id = self.registers.get(*array_id_reg);
                 let heap = &mut self.memory.entry(array_id).or_default().memory_map;
-                heap.insert(*index, source_value);
+
+                let index_value = self.registers.get(*index);
+                let index_usize = usize::try_from(
+                    index_value.inner.try_to_u64().expect("register does not fit into u64"),
+                )
+                .expect("register does not fit into usize");
+                heap.insert(index_usize, source_value);
                 self.increment_program_counter()
             }
         }
@@ -483,7 +494,7 @@ fn load_opcode() {
     let load_opcode = Opcode::Load {
         destination: RegisterMemIndex::Register(RegisterIndex(4)),
         array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
-        index: 1,
+        index: RegisterMemIndex::Register(RegisterIndex(2)),
     };
 
     let mem_equal_opcode = Opcode::BinaryOp {
@@ -566,7 +577,7 @@ fn store_opcode() {
     let store_opcode = Opcode::Store {
         source: RegisterMemIndex::Register(RegisterIndex(2)),
         array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
-        index: 3,
+        index: RegisterMemIndex::Constant(FieldElement::from(3_u128)),
     };
 
     let mut initial_memory = BTreeMap::new();
@@ -598,7 +609,6 @@ fn store_opcode() {
     // jump_opcode
     let status = vm.process_opcode();
     assert_eq!(status, VMStatus::InProgress);
-    dbg!(status);
 
     // jump_if_opcode
     let status = vm.process_opcode();

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -66,12 +66,12 @@ pub enum Opcode {
     Load {
         destination: RegisterMemIndex,
         array_id_reg: RegisterMemIndex,
-        index: usize,
+        index: RegisterMemIndex,
     },
     Store {
         source: RegisterMemIndex,
         array_id_reg: RegisterMemIndex,
-        index: usize,
+        index: RegisterMemIndex,
     },
     /// Used if execution fails during evaluation
     Trap,

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -63,6 +63,16 @@ pub enum Opcode {
         destination: RegisterMemIndex,
         source: RegisterMemIndex,
     },
+    Load {
+        destination: RegisterMemIndex,
+        array_id_reg: RegisterMemIndex,
+        index: usize,
+    },
+    Store {
+        source: RegisterMemIndex,
+        array_id_reg: RegisterMemIndex,
+        index: usize,
+    },
     /// Used if execution fails during evaluation
     Trap,
     /// Hack
@@ -84,6 +94,8 @@ impl Opcode {
             Opcode::Intrinsics => "intrinsics",
             Opcode::Oracle(_) => "oracle",
             Opcode::Mov { .. } => "mov",
+            Opcode::Load { .. } => "load",
+            Opcode::Store { .. } => "store",
             Opcode::Trap => "trap",
             Opcode::Bootstrap { .. } => "bootstrap",
             Opcode::Stop => "stop",

--- a/brillig_bytecode/src/registers.rs
+++ b/brillig_bytecode/src/registers.rs
@@ -9,6 +9,32 @@ pub struct Registers {
     pub inner: Vec<Value>,
 }
 
+impl IntoIterator for Registers {
+    type Item = Value;
+    type IntoIter = RegistersIntoIterator;
+
+    fn into_iter(self) -> Self::IntoIter {
+        RegistersIntoIterator { registers: self, index: 0 }
+    }
+}
+pub struct RegistersIntoIterator {
+    registers: Registers,
+    index: usize,
+}
+
+impl Iterator for RegistersIntoIterator {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index >= self.registers.inner.len() {
+            return None;
+        }
+
+        self.index += 1;
+        Some(self.registers.inner[self.index - 1])
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterIndex(pub usize);
 

--- a/brillig_bytecode/src/value.rs
+++ b/brillig_bytecode/src/value.rs
@@ -8,7 +8,6 @@ pub enum Typ {
     Field,
     Unsigned { bit_size: u32 },
     Signed { bit_size: u32 },
-    ArrayId,
 }
 
 /// Value represents a Value in the VM
@@ -31,7 +30,6 @@ impl Value {
                 todo!("TODO")
             }
             Typ::Signed { bit_size } => todo!("TODO"),
-            Typ::ArrayId => self.inner.inverse(),
         };
         Value { typ: self.typ, inner: value }
     }

--- a/brillig_bytecode/src/value.rs
+++ b/brillig_bytecode/src/value.rs
@@ -8,6 +8,7 @@ pub enum Typ {
     Field,
     Unsigned { bit_size: u32 },
     Signed { bit_size: u32 },
+    ArrayId,
 }
 
 /// Value represents a Value in the VM
@@ -30,6 +31,7 @@ impl Value {
                 todo!("TODO")
             }
             Typ::Signed { bit_size } => todo!("TODO"),
+            Typ::ArrayId => self.inner.inverse(),
         };
         Value { typ: self.typ, inner: value }
     }
@@ -44,6 +46,12 @@ impl From<u128> for Value {
 impl From<FieldElement> for Value {
     fn from(value: FieldElement) -> Self {
         Value { typ: Typ::Field, inner: value }
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Value { typ: Typ::Field, inner: FieldElement::from(value as i128) }
     }
 }
 


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
