### PR TITLE
feat: Brillig oracle array outputs

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -483,7 +483,7 @@ mod test {
             name: "invert".into(),
             inputs: vec![RegisterMemIndex::Register(RegisterIndex(0))],
             input_values: vec![],
-            outputs: vec![RegisterIndex(1)],
+            output: RegisterIndex(1),
             output_values: vec![],
         });
 
@@ -626,7 +626,7 @@ mod test {
             name: "invert".into(),
             inputs: vec![RegisterMemIndex::Register(RegisterIndex(0))],
             input_values: vec![],
-            outputs: vec![RegisterIndex(1)],
+            output: RegisterIndex(1),
             output_values: vec![],
         });
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -643,9 +643,7 @@ fn oracle_array_output() {
 
     let oracle_opcode = Opcode::Oracle(oracle_data.clone());
 
-    let mut initial_memory = BTreeMap::new();
-    let initial_heap = ArrayHeap { memory_map: BTreeMap::new() };
-    initial_memory.insert(Value::from(5u128), initial_heap);
+    let initial_memory = BTreeMap::new();
 
     let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -10,8 +10,6 @@ mod opcodes;
 mod registers;
 mod value;
 
-use std::array;
-use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
 use acir_field::FieldElement;
@@ -120,9 +118,9 @@ impl VM {
             Opcode::Intrinsics => todo!(),
             Opcode::Oracle(data) => {
                 if data.output_values.len() == 1 {
-                    self.registers.set(data.outputs[0], data.output_values[0].into());
+                    self.registers.set(data.output, data.output_values[0].into());
                 } else if data.output_values.len() > 1 {
-                    let register = self.registers.get(RegisterMemIndex::Register(data.outputs[0]));
+                    let register = self.registers.get(RegisterMemIndex::Register(data.output));
                     let heap = &mut self.memory.entry(register).or_default().memory_map;
                     for (i, value) in data.output_values.iter().enumerate() {
                         heap.insert(i, (*value).into());
@@ -639,7 +637,7 @@ fn oracle_array_output() {
         name: "get_notes".to_owned(),
         inputs: vec![RegisterMemIndex::Register(RegisterIndex(0))],
         input_values: vec![],
-        outputs: vec![RegisterIndex(3)],
+        output: RegisterIndex(3),
         output_values: vec![],
     };
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -11,6 +11,7 @@ mod registers;
 mod value;
 
 use std::array;
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 
 use acir_field::FieldElement;
@@ -118,9 +119,13 @@ impl VM {
             }
             Opcode::Intrinsics => todo!(),
             Opcode::Oracle(data) => {
-                if data.outputs.len() == data.output_values.len() {
-                    for (index, value) in data.outputs.iter().zip(data.output_values.iter()) {
-                        self.registers.set(*index, (*value).into())
+                if data.output_values.len() == 1 {
+                    self.registers.set(data.outputs[0], data.output_values[0].into());
+                } else if data.output_values.len() > 1 {
+                    let register = self.registers.get(RegisterMemIndex::Register(data.outputs[0]));
+                    let heap = &mut self.memory.entry(register).or_default().memory_map;
+                    for (i, value) in data.output_values.iter().enumerate() {
+                        heap.insert(i, (*value).into());
                     }
                 } else {
                     self.status = VMStatus::OracleWait;
@@ -616,4 +621,55 @@ fn store_opcode() {
     assert_eq!(status, VMStatus::Halted);
 
     vm.finish();
+}
+
+#[test]
+fn oracle_array_output() {
+    let input_registers = Registers::load(vec![
+        Value::from(2u128),
+        Value::from(2u128),
+        Value::from(0u128),
+        Value::from(5u128),
+        Value::from(0u128),
+        Value::from(6u128),
+        Value::from(0u128),
+    ]);
+
+    let mut oracle_data = OracleData {
+        name: "get_notes".to_owned(),
+        inputs: vec![RegisterMemIndex::Register(RegisterIndex(0))],
+        input_values: vec![],
+        outputs: vec![RegisterIndex(3)],
+        output_values: vec![],
+    };
+
+    let oracle_opcode = Opcode::Oracle(oracle_data.clone());
+
+    let mut initial_memory = BTreeMap::new();
+    let initial_heap = ArrayHeap { memory_map: BTreeMap::new() };
+    initial_memory.insert(Value::from(5u128), initial_heap);
+
+    let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
+
+    let output_state = vm.process_opcodes();
+    assert_eq!(output_state.status, VMStatus::OracleWait);
+
+    let input_values = oracle_data
+        .clone()
+        .inputs
+        .into_iter()
+        .map(|register_mem_index| output_state.registers.get(register_mem_index).inner)
+        .collect::<Vec<_>>();
+
+    oracle_data.input_values = input_values;
+    oracle_data.output_values = vec![FieldElement::from(10_u128), FieldElement::from(2_u128)];
+    let updated_oracle_opcode = Opcode::Oracle(oracle_data);
+
+    let vm = VM::new(input_registers, output_state.memory, vec![updated_oracle_opcode]);
+    let output_state = vm.process_opcodes();
+    assert_eq!(output_state.status, VMStatus::Halted);
+
+    let mem_array = output_state.memory[&Value::from(5u128)].clone();
+    assert_eq!(mem_array.memory_map[&0], Value::from(10_u128));
+    assert_eq!(mem_array.memory_map[&1], Value::from(2_u128));
 }

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -107,12 +107,12 @@ impl Opcode {
 pub struct OracleData {
     /// Name of the oracle
     pub name: String,
-    /// Inputs
+    /// Input registers
     pub inputs: Vec<RegisterMemIndex>,
     /// Input values
     pub input_values: Vec<FieldElement>,
-    /// Output witness
-    pub outputs: Vec<RegisterIndex>,
+    /// Output register
+    pub output: RegisterIndex,
     /// Output values - they are computed by the (external) oracle once the inputs are known
     pub output_values: Vec<FieldElement>,
 }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

This handles array outputs being returned from an oracle function. For complex types such as structs or nested structs the VM assumed these have been flattened when setting the Brillig bytecode.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
