### PR TITLE
fix: Change OracleInput to an enum

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -490,10 +490,8 @@ mod test {
             result: RegisterIndex(3),
         };
 
-        let invert_oracle_input = OracleInput {
-            register_mem_index: RegisterMemIndex::Register(RegisterIndex(0)),
-            length: 0,
-        };
+        let invert_oracle_input =
+            OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
 
         let invert_oracle = brillig_bytecode::Opcode::Oracle(brillig_bytecode::OracleData {
             name: "invert".into(),
@@ -617,10 +615,8 @@ mod test {
             result: RegisterIndex(3),
         };
 
-        let invert_oracle_input = OracleInput {
-            register_mem_index: RegisterMemIndex::Register(RegisterIndex(0)),
-            length: 0,
-        };
+        let invert_oracle_input =
+            OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
 
         let invert_oracle = brillig_bytecode::Opcode::Oracle(brillig_bytecode::OracleData {
             name: "invert".into(),

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -210,7 +210,7 @@ impl VM {
         lhs: RegisterMemIndex,
         rhs: RegisterMemIndex,
         result: RegisterIndex,
-        result_type: Typ,
+        _result_type: Typ,
     ) {
         let lhs_value = self.registers.get(lhs);
         let rhs_value = self.registers.get(rhs);
@@ -240,510 +240,523 @@ pub struct VMOutputState {
     pub memory: BTreeMap<Value, ArrayHeap>,
 }
 
-#[test]
-fn add_single_step_smoke() {
-    // Load values into registers and initialize the registers that
-    // will be used during bytecode processing
-    let input_registers =
-        Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(0u128)]);
-
-    // Add opcode to add the value in register `0` and `1`
-    // and place the output in register `2`
-    let opcode = Opcode::BinaryOp {
-        op: BinaryOp::Add,
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-        result_type: Typ::Field,
-    };
-
-    // Start VM
-    let mut vm = VM::new(input_registers, BTreeMap::new(), vec![opcode]);
-
-    // Process a single VM opcode
-    //
-    // After processing a single opcode, we should have
-    // the vm status as halted since there is only one opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    // The register at index `2` should have the value of 3 since we had an
-    // add opcode
-    let VMOutputState { registers, .. } = vm.finish();
-    let output_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-
-    assert_eq!(output_value, Value::from(3u128))
-}
-
-#[test]
-fn jmpif_opcode() {
-    let input_registers =
-        Registers::load(vec![Value::from(2u128), Value::from(2u128), Value::from(0u128)]);
-
-    let equal_cmp_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let jump_opcode = Opcode::JMP { destination: 2 };
-
-    let jump_if_opcode =
-        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 3 };
-
-    let mut vm = VM::new(
-        input_registers,
-        BTreeMap::new(),
-        vec![equal_cmp_opcode, jump_opcode, jump_if_opcode],
-    );
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    vm.finish();
-}
-
-#[test]
-fn jmpifnot_opcode() {
-    let input_registers =
-        Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(0u128)]);
-
-    let trap_opcode = Opcode::Trap;
-
-    let not_equal_cmp_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let jump_opcode = Opcode::JMP { destination: 2 };
-
-    let jump_if_not_opcode = Opcode::JMPIFNOT {
-        condition: RegisterMemIndex::Register(RegisterIndex(2)),
-        destination: 1,
-    };
-
-    let add_opcode = Opcode::BinaryOp {
-        op: BinaryOp::Add,
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-        result_type: Typ::Field,
-    };
-
-    let mut vm = VM::new(
-        input_registers,
-        BTreeMap::new(),
-        vec![jump_opcode, trap_opcode, not_equal_cmp_opcode, jump_if_not_opcode, add_opcode],
-    );
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_cmp_value, Value::from(false));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Failure);
-
-    // The register at index `2` should have not changed as we jumped over the add opcode
-    let VMOutputState { registers, .. } = vm.finish();
-    let output_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_value, Value::from(false));
-}
-
-#[test]
-fn mov_opcode() {
-    let input_registers =
-        Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(3u128)]);
-
-    let mov_opcode = Opcode::Mov {
-        destination: RegisterMemIndex::Register(RegisterIndex(2)),
-        source: RegisterMemIndex::Register(RegisterIndex(0)),
-    };
-
-    let mut vm = VM::new(input_registers, BTreeMap::new(), vec![mov_opcode]);
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    let VMOutputState { registers, .. } = vm.finish();
-
-    let destination_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(destination_value, Value::from(1u128));
-
-    let source_value = registers.get(RegisterMemIndex::Register(RegisterIndex(0)));
-    assert_eq!(source_value, Value::from(1u128));
-}
-
-#[test]
-fn cmp_binary_ops() {
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(6u128),
-    ]);
-
-    let equal_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let not_equal_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(3)),
-        result: RegisterIndex(2),
-    };
-
-    let less_than_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Lt),
-        lhs: RegisterMemIndex::Register(RegisterIndex(3)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(4)),
-        result: RegisterIndex(2),
-    };
-
-    let less_than_equal_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Lte),
-        lhs: RegisterMemIndex::Register(RegisterIndex(3)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(4)),
-        result: RegisterIndex(2),
-    };
-
-    let mut vm = VM::new(
-        input_registers,
-        BTreeMap::new(),
-        vec![equal_opcode, not_equal_opcode, less_than_opcode, less_than_equal_opcode],
-    );
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_eq_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_eq_value, Value::from(true));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_neq_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_neq_value, Value::from(false));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let lt_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(lt_value, Value::from(true));
-
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    let lte_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(lte_value, Value::from(true));
-
-    vm.finish();
-}
-
-#[test]
-fn load_opcode() {
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(0u128),
-        Value::from(6u128),
-        Value::from(0u128),
-    ]);
-
-    let equal_cmp_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let jump_opcode = Opcode::JMP { destination: 3 };
-
-    let jump_if_opcode =
-        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 10 };
-
-    let load_opcode = Opcode::Load {
-        destination: RegisterMemIndex::Register(RegisterIndex(4)),
-        array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
-        index: RegisterMemIndex::Register(RegisterIndex(2)),
-    };
-
-    let mem_equal_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(4)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(5)),
-        result: RegisterIndex(6),
-    };
-
-    let mut initial_memory = BTreeMap::new();
-    let initial_heap = ArrayHeap {
-        memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
-    };
-    initial_memory.insert(Value::from(5u128), initial_heap);
-
-    let mut vm = VM::new(
-        input_registers,
-        initial_memory,
-        vec![equal_cmp_opcode, load_opcode, jump_opcode, mem_equal_opcode, jump_if_opcode],
-    );
-
-    // equal_cmp_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    // load_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(4)));
-    assert_eq!(output_cmp_value, Value::from(6u128));
-
-    // jump_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    // mem_equal_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(6)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    // jump_if_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    vm.finish();
-}
-
-#[test]
-fn store_opcode() {
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(0u128),
-        Value::from(6u128),
-        Value::from(0u128),
-    ]);
-
-    let equal_cmp_opcode = Opcode::BinaryOp {
-        result_type: Typ::Field,
-        op: BinaryOp::Cmp(Comparison::Eq),
-        lhs: RegisterMemIndex::Register(RegisterIndex(0)),
-        rhs: RegisterMemIndex::Register(RegisterIndex(1)),
-        result: RegisterIndex(2),
-    };
-
-    let jump_opcode = Opcode::JMP { destination: 3 };
-
-    let jump_if_opcode =
-        Opcode::JMPIF { condition: RegisterMemIndex::Register(RegisterIndex(2)), destination: 10 };
-
-    let store_opcode = Opcode::Store {
-        source: RegisterMemIndex::Register(RegisterIndex(2)),
-        array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
-        index: RegisterMemIndex::Constant(FieldElement::from(3_u128)),
-    };
-
-    let mut initial_memory = BTreeMap::new();
-    let initial_heap = ArrayHeap {
-        memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
-    };
-    initial_memory.insert(Value::from(5u128), initial_heap);
-
-    let mut vm = VM::new(
-        input_registers,
-        initial_memory,
-        vec![equal_cmp_opcode, store_opcode, jump_opcode, jump_if_opcode],
-    );
-
-    // equal_cmp_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
-    assert_eq!(output_cmp_value, Value::from(true));
-
-    // store_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    let mem_array = vm.memory[&Value::from(5u128)].clone();
-    assert_eq!(mem_array.memory_map[&3], Value::from(true));
-
-    // jump_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::InProgress);
-
-    // jump_if_opcode
-    let status = vm.process_opcode();
-    assert_eq!(status, VMStatus::Halted);
-
-    vm.finish();
-}
-
-#[test]
-fn oracle_array_output() {
-    use crate::opcodes::OracleInput;
-
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(0u128),
-        Value::from(6u128),
-        Value::from(0u128),
-    ]);
-
-    let oracle_input =
-        OracleInput { register_mem_index: RegisterMemIndex::Register(RegisterIndex(0)), length: 0 };
-
-    let mut oracle_data = OracleData {
-        name: "get_notes".to_owned(),
-        inputs: vec![oracle_input],
-        input_values: vec![],
-        output: RegisterIndex(3),
-        output_values: vec![],
-    };
-
-    let oracle_opcode = Opcode::Oracle(oracle_data.clone());
-
-    let initial_memory = BTreeMap::new();
-
-    let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
-
-    let output_state = vm.process_opcodes();
-    assert_eq!(output_state.status, VMStatus::OracleWait);
-
-    let mut input_values = Vec::new();
-    for oracle_input in oracle_data.clone().inputs {
-        if oracle_input.length == 0 {
-            let x = output_state.registers.get(oracle_input.register_mem_index).inner;
-            input_values.push(x);
-        } else {
-            let array_id = output_state.registers.get(oracle_input.register_mem_index);
-            let array = output_state.memory[&array_id].clone();
-            let heap_fields =
-                array.memory_map.into_values().map(|value| value.inner).collect::<Vec<_>>();
-            input_values.extend(heap_fields);
+impl VMOutputState {
+    pub fn map_input_values(&self, oracle_data: &OracleData) -> Vec<FieldElement> {
+        let mut input_values = vec![];
+        for oracle_input in &oracle_data.inputs {
+            match oracle_input {
+                OracleInput::RegisterMemIndex(register_index) => {
+                    let register = self.registers.get(*register_index);
+                    input_values.push(register.inner);
+                }
+                OracleInput::Array { start, length } => {
+                    let array_id = self.registers.get(*start);
+                    let array = &self.memory[&array_id];
+                    let heap_fields = array.memory_map.values().map(|value| value.inner.clone());
+
+                    assert_eq!(heap_fields.len(), *length);
+                    input_values.extend(heap_fields);
+                }
+            }
         }
+        input_values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_single_step_smoke() {
+        // Load values into registers and initialize the registers that
+        // will be used during bytecode processing
+        let input_registers =
+            Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(0u128)]);
+
+        // Add opcode to add the value in register `0` and `1`
+        // and place the output in register `2`
+        let opcode = Opcode::BinaryOp {
+            op: BinaryOp::Add,
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+            result_type: Typ::Field,
+        };
+
+        // Start VM
+        let mut vm = VM::new(input_registers, BTreeMap::new(), vec![opcode]);
+
+        // Process a single VM opcode
+        //
+        // After processing a single opcode, we should have
+        // the vm status as halted since there is only one opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
+
+        // The register at index `2` should have the value of 3 since we had an
+        // add opcode
+        let VMOutputState { registers, .. } = vm.finish();
+        let output_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+
+        assert_eq!(output_value, Value::from(3u128))
     }
 
-    oracle_data.input_values = input_values;
-    oracle_data.output_values = vec![FieldElement::from(10_u128), FieldElement::from(2_u128)];
-    let updated_oracle_opcode = Opcode::Oracle(oracle_data);
+    #[test]
+    fn jmpif_opcode() {
+        let input_registers =
+            Registers::load(vec![Value::from(2u128), Value::from(2u128), Value::from(0u128)]);
 
-    let vm = VM::new(input_registers, output_state.memory, vec![updated_oracle_opcode]);
-    let output_state = vm.process_opcodes();
-    assert_eq!(output_state.status, VMStatus::Halted);
+        let equal_cmp_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+        };
 
-    let mem_array = output_state.memory[&Value::from(5u128)].clone();
-    assert_eq!(mem_array.memory_map[&0], Value::from(10_u128));
-    assert_eq!(mem_array.memory_map[&1], Value::from(2_u128));
-}
+        let jump_opcode = Opcode::JMP { destination: 2 };
 
-#[test]
-fn oracle_array_input() {
-    use crate::opcodes::OracleInput;
+        let jump_if_opcode = Opcode::JMPIF {
+            condition: RegisterMemIndex::Register(RegisterIndex(2)),
+            destination: 3,
+        };
 
-    let input_registers = Registers::load(vec![
-        Value::from(2u128),
-        Value::from(2u128),
-        Value::from(0u128),
-        Value::from(5u128),
-        Value::from(0u128),
-        Value::from(6u128),
-        Value::from(0u128),
-    ]);
+        let mut vm = VM::new(
+            input_registers,
+            BTreeMap::new(),
+            vec![equal_cmp_opcode, jump_opcode, jump_if_opcode],
+        );
 
-    let oracle_input =
-        OracleInput { register_mem_index: RegisterMemIndex::Register(RegisterIndex(3)), length: 2 };
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
 
-    let mut oracle_data = OracleData {
-        name: "call_private_function_oracle".to_owned(),
-        inputs: vec![oracle_input.clone()],
-        input_values: vec![],
-        output: RegisterIndex(6),
-        output_values: vec![],
-    };
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_cmp_value, Value::from(true));
 
-    let oracle_opcode = Opcode::Oracle(oracle_data.clone());
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
 
-    let mut initial_memory = BTreeMap::new();
-    let initial_heap = ArrayHeap {
-        memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
-    };
-    initial_memory.insert(Value::from(5u128), initial_heap);
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
 
-    let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
-
-    let output_state = vm.process_opcodes();
-    assert_eq!(output_state.status, VMStatus::OracleWait);
-
-    let mut input_values = Vec::new();
-    for oracle_input in oracle_data.clone().inputs {
-        if oracle_input.length == 0 {
-            let x = output_state.registers.get(oracle_input.register_mem_index).inner;
-            input_values.push(x);
-        } else {
-            let array_id = output_state.registers.get(oracle_input.register_mem_index);
-            let array = output_state.memory[&array_id].clone();
-            let heap_fields =
-                array.memory_map.into_values().map(|value| value.inner).collect::<Vec<_>>();
-            input_values.extend(heap_fields);
-        }
+        vm.finish();
     }
-    assert_eq!(input_values.len(), oracle_input.length);
 
-    oracle_data.input_values = input_values;
-    oracle_data.output_values = vec![FieldElement::from(5_u128)];
-    let updated_oracle_opcode = Opcode::Oracle(oracle_data);
+    #[test]
+    fn jmpifnot_opcode() {
+        let input_registers =
+            Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(0u128)]);
 
-    let vm = VM::new(input_registers, output_state.memory, vec![updated_oracle_opcode]);
-    let output_state = vm.process_opcodes();
-    assert_eq!(output_state.status, VMStatus::Halted);
+        let trap_opcode = Opcode::Trap;
 
-    let mem_array = output_state.memory[&Value::from(5u128)].clone();
-    assert_eq!(mem_array.memory_map[&0], Value::from(5_u128));
-    assert_eq!(mem_array.memory_map[&1], Value::from(6_u128));
+        let not_equal_cmp_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+        };
+
+        let jump_opcode = Opcode::JMP { destination: 2 };
+
+        let jump_if_not_opcode = Opcode::JMPIFNOT {
+            condition: RegisterMemIndex::Register(RegisterIndex(2)),
+            destination: 1,
+        };
+
+        let add_opcode = Opcode::BinaryOp {
+            op: BinaryOp::Add,
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+            result_type: Typ::Field,
+        };
+
+        let mut vm = VM::new(
+            input_registers,
+            BTreeMap::new(),
+            vec![jump_opcode, trap_opcode, not_equal_cmp_opcode, jump_if_not_opcode, add_opcode],
+        );
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_cmp_value, Value::from(false));
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Failure);
+
+        // The register at index `2` should have not changed as we jumped over the add opcode
+        let VMOutputState { registers, .. } = vm.finish();
+        let output_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_value, Value::from(false));
+    }
+
+    #[test]
+    fn mov_opcode() {
+        let input_registers =
+            Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(3u128)]);
+
+        let mov_opcode = Opcode::Mov {
+            destination: RegisterMemIndex::Register(RegisterIndex(2)),
+            source: RegisterMemIndex::Register(RegisterIndex(0)),
+        };
+
+        let mut vm = VM::new(input_registers, BTreeMap::new(), vec![mov_opcode]);
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
+
+        let VMOutputState { registers, .. } = vm.finish();
+
+        let destination_value = registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(destination_value, Value::from(1u128));
+
+        let source_value = registers.get(RegisterMemIndex::Register(RegisterIndex(0)));
+        assert_eq!(source_value, Value::from(1u128));
+    }
+
+    #[test]
+    fn cmp_binary_ops() {
+        let input_registers = Registers::load(vec![
+            Value::from(2u128),
+            Value::from(2u128),
+            Value::from(0u128),
+            Value::from(5u128),
+            Value::from(6u128),
+        ]);
+
+        let equal_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+        };
+
+        let not_equal_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(3)),
+            result: RegisterIndex(2),
+        };
+
+        let less_than_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Lt),
+            lhs: RegisterMemIndex::Register(RegisterIndex(3)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(4)),
+            result: RegisterIndex(2),
+        };
+
+        let less_than_equal_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Lte),
+            lhs: RegisterMemIndex::Register(RegisterIndex(3)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(4)),
+            result: RegisterIndex(2),
+        };
+
+        let mut vm = VM::new(
+            input_registers,
+            BTreeMap::new(),
+            vec![equal_opcode, not_equal_opcode, less_than_opcode, less_than_equal_opcode],
+        );
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_eq_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_eq_value, Value::from(true));
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_neq_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_neq_value, Value::from(false));
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let lt_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(lt_value, Value::from(true));
+
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
+
+        let lte_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(lte_value, Value::from(true));
+
+        vm.finish();
+    }
+
+    #[test]
+    fn load_opcode() {
+        let input_registers = Registers::load(vec![
+            Value::from(2u128),
+            Value::from(2u128),
+            Value::from(0u128),
+            Value::from(5u128),
+            Value::from(0u128),
+            Value::from(6u128),
+            Value::from(0u128),
+        ]);
+
+        let equal_cmp_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+        };
+
+        let jump_opcode = Opcode::JMP { destination: 3 };
+
+        let jump_if_opcode = Opcode::JMPIF {
+            condition: RegisterMemIndex::Register(RegisterIndex(2)),
+            destination: 10,
+        };
+
+        let load_opcode = Opcode::Load {
+            destination: RegisterMemIndex::Register(RegisterIndex(4)),
+            array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
+            index: RegisterMemIndex::Register(RegisterIndex(2)),
+        };
+
+        let mem_equal_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(4)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(5)),
+            result: RegisterIndex(6),
+        };
+
+        let mut initial_memory = BTreeMap::new();
+        let initial_heap = ArrayHeap {
+            memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
+        };
+        initial_memory.insert(Value::from(5u128), initial_heap);
+
+        let mut vm = VM::new(
+            input_registers,
+            initial_memory,
+            vec![equal_cmp_opcode, load_opcode, jump_opcode, mem_equal_opcode, jump_if_opcode],
+        );
+
+        // equal_cmp_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_cmp_value, Value::from(true));
+
+        // load_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(4)));
+        assert_eq!(output_cmp_value, Value::from(6u128));
+
+        // jump_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        // mem_equal_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(6)));
+        assert_eq!(output_cmp_value, Value::from(true));
+
+        // jump_if_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
+
+        vm.finish();
+    }
+
+    #[test]
+    fn store_opcode() {
+        let input_registers = Registers::load(vec![
+            Value::from(2u128),
+            Value::from(2u128),
+            Value::from(0u128),
+            Value::from(5u128),
+            Value::from(0u128),
+            Value::from(6u128),
+            Value::from(0u128),
+        ]);
+
+        let equal_cmp_opcode = Opcode::BinaryOp {
+            result_type: Typ::Field,
+            op: BinaryOp::Cmp(Comparison::Eq),
+            lhs: RegisterMemIndex::Register(RegisterIndex(0)),
+            rhs: RegisterMemIndex::Register(RegisterIndex(1)),
+            result: RegisterIndex(2),
+        };
+
+        let jump_opcode = Opcode::JMP { destination: 3 };
+
+        let jump_if_opcode = Opcode::JMPIF {
+            condition: RegisterMemIndex::Register(RegisterIndex(2)),
+            destination: 10,
+        };
+
+        let store_opcode = Opcode::Store {
+            source: RegisterMemIndex::Register(RegisterIndex(2)),
+            array_id_reg: RegisterMemIndex::Register(RegisterIndex(3)),
+            index: RegisterMemIndex::Constant(FieldElement::from(3_u128)),
+        };
+
+        let mut initial_memory = BTreeMap::new();
+        let initial_heap = ArrayHeap {
+            memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
+        };
+        initial_memory.insert(Value::from(5u128), initial_heap);
+
+        let mut vm = VM::new(
+            input_registers,
+            initial_memory,
+            vec![equal_cmp_opcode, store_opcode, jump_opcode, jump_if_opcode],
+        );
+
+        // equal_cmp_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let output_cmp_value = vm.registers.get(RegisterMemIndex::Register(RegisterIndex(2)));
+        assert_eq!(output_cmp_value, Value::from(true));
+
+        // store_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        let mem_array = vm.memory[&Value::from(5u128)].clone();
+        assert_eq!(mem_array.memory_map[&3], Value::from(true));
+
+        // jump_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::InProgress);
+
+        // jump_if_opcode
+        let status = vm.process_opcode();
+        assert_eq!(status, VMStatus::Halted);
+
+        vm.finish();
+    }
+
+    #[test]
+    fn oracle_array_output() {
+        use crate::opcodes::OracleInput;
+
+        let input_registers = Registers::load(vec![
+            Value::from(2u128),
+            Value::from(2u128),
+            Value::from(0u128),
+            Value::from(5u128),
+            Value::from(0u128),
+            Value::from(6u128),
+            Value::from(0u128),
+        ]);
+
+        let oracle_input =
+            OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
+
+        let mut oracle_data = OracleData {
+            name: "get_notes".to_owned(),
+            inputs: vec![oracle_input],
+            input_values: vec![],
+            output: RegisterIndex(3),
+            output_values: vec![],
+        };
+
+        let oracle_opcode = Opcode::Oracle(oracle_data.clone());
+
+        let initial_memory = BTreeMap::new();
+
+        let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
+
+        let output_state = vm.process_opcodes();
+        assert_eq!(output_state.status, VMStatus::OracleWait);
+
+        let input_values = output_state.map_input_values(&oracle_data);
+
+        oracle_data.input_values = input_values;
+        oracle_data.output_values = vec![FieldElement::from(10_u128), FieldElement::from(2_u128)];
+        let updated_oracle_opcode = Opcode::Oracle(oracle_data);
+
+        let vm = VM::new(input_registers, output_state.memory, vec![updated_oracle_opcode]);
+        let output_state = vm.process_opcodes();
+        assert_eq!(output_state.status, VMStatus::Halted);
+
+        let mem_array = output_state.memory[&Value::from(5u128)].clone();
+        assert_eq!(mem_array.memory_map[&0], Value::from(10_u128));
+        assert_eq!(mem_array.memory_map[&1], Value::from(2_u128));
+    }
+
+    #[test]
+    fn oracle_array_input() {
+        use crate::opcodes::OracleInput;
+
+        let input_registers = Registers::load(vec![
+            Value::from(2u128),
+            Value::from(2u128),
+            Value::from(0u128),
+            Value::from(5u128),
+            Value::from(0u128),
+            Value::from(6u128),
+            Value::from(0u128),
+        ]);
+
+        let expected_length = 2;
+        let oracle_input = OracleInput::Array {
+            start: RegisterMemIndex::Register(RegisterIndex(3)),
+            length: expected_length,
+        };
+
+        let mut oracle_data = OracleData {
+            name: "call_private_function_oracle".to_owned(),
+            inputs: vec![oracle_input.clone()],
+            input_values: vec![],
+            output: RegisterIndex(6),
+            output_values: vec![],
+        };
+
+        let oracle_opcode = Opcode::Oracle(oracle_data.clone());
+
+        let mut initial_memory = BTreeMap::new();
+        let initial_heap = ArrayHeap {
+            memory_map: BTreeMap::from([(0 as usize, Value::from(5u128)), (1, Value::from(6u128))]),
+        };
+        initial_memory.insert(Value::from(5u128), initial_heap);
+
+        let vm = VM::new(input_registers.clone(), initial_memory, vec![oracle_opcode]);
+
+        let output_state = vm.process_opcodes();
+        assert_eq!(output_state.status, VMStatus::OracleWait);
+
+        let input_values = output_state.map_input_values(&oracle_data);
+        assert_eq!(input_values.len(), expected_length);
+
+        oracle_data.input_values = input_values;
+        oracle_data.output_values = vec![FieldElement::from(5_u128)];
+        let updated_oracle_opcode = Opcode::Oracle(oracle_data);
+
+        let vm = VM::new(input_registers, output_state.memory, vec![updated_oracle_opcode]);
+        let output_state = vm.process_opcodes();
+        assert_eq!(output_state.status, VMStatus::Halted);
+
+        let mem_array = output_state.memory[&Value::from(5u128)].clone();
+        assert_eq!(mem_array.memory_map[&0], Value::from(5_u128));
+        assert_eq!(mem_array.memory_map[&1], Value::from(6_u128));
+    }
 }

--- a/brillig_bytecode/src/memory.rs
+++ b/brillig_bytecode/src/memory.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+
 /// Memory in the VM is used for storing arrays
 ///
 /// ArrayIndex will be used to reference an Array element.

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -118,9 +118,9 @@ pub struct OracleData {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct OracleInput {
-    pub register_mem_index: RegisterMemIndex,
-    pub length: usize,
+pub enum OracleInput {
+    RegisterMemIndex(RegisterMemIndex),
+    Array { start: RegisterMemIndex, length: usize },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/brillig_bytecode/src/value.rs
+++ b/brillig_bytecode/src/value.rs
@@ -26,10 +26,10 @@ impl Value {
     pub fn inverse(&self) -> Value {
         let value = match self.typ {
             Typ::Field => self.inner.inverse(),
-            Typ::Unsigned { bit_size } => {
+            Typ::Unsigned { bit_size: _ } => {
                 todo!("TODO")
             }
-            Typ::Signed { bit_size } => todo!("TODO"),
+            Typ::Signed { bit_size: _ } => todo!("TODO"),
         };
         Value { typ: self.typ, inner: value }
     }


### PR DESCRIPTION
# Related issue(s)

No issue, fixes an issue from the #199 PR which was merged before my review

# Description

## Summary of changes

Changes OracleInput from a struct to an enumeration.
Also adds a helper method on VMOutputState to map the input values since I found the code was repeated three times.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
