### PR TITLE
feat!: Use OracleOutput enum in OracleData

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -359,7 +359,7 @@ mod test {
     use acir::{
         brillig_bytecode,
         brillig_bytecode::{
-            BinaryOp, Comparison, OracleInput, RegisterIndex, RegisterMemIndex, Typ,
+            BinaryOp, Comparison, OracleInput, OracleOutput, RegisterIndex, RegisterMemIndex, Typ,
         },
         circuit::{
             directives::Directive,
@@ -492,12 +492,13 @@ mod test {
 
         let invert_oracle_input =
             OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
+        let invert_oracle_output = OracleOutput::RegisterIndex(RegisterIndex(1));
 
         let invert_oracle = brillig_bytecode::Opcode::Oracle(brillig_bytecode::OracleData {
             name: "invert".into(),
             inputs: vec![invert_oracle_input],
             input_values: vec![],
-            output: RegisterIndex(1),
+            outputs: vec![invert_oracle_output],
             output_values: vec![],
         });
 
@@ -617,12 +618,13 @@ mod test {
 
         let invert_oracle_input =
             OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
+        let invert_oracle_output = OracleOutput::RegisterIndex(RegisterIndex(1));
 
         let invert_oracle = brillig_bytecode::Opcode::Oracle(brillig_bytecode::OracleData {
             name: "invert".into(),
             inputs: vec![invert_oracle_input],
             input_values: vec![],
-            output: RegisterIndex(1),
+            outputs: vec![invert_oracle_output],
             output_values: vec![],
         });
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -117,18 +117,6 @@ impl VM {
             }
             Opcode::Intrinsics => todo!(),
             Opcode::Oracle(data) => {
-                // if data.output_values.len() == 1 {
-                //     self.registers.set(data.output, data.output_values[0].into());
-                // } else if data.output_values.len() > 1 {
-                //     let register = self.registers.get(RegisterMemIndex::Register(data.output));
-                //     let heap = &mut self.memory.entry(register).or_default().memory_map;
-                //     for (i, value) in data.output_values.iter().enumerate() {
-                //         heap.insert(i, (*value).into());
-                //     }
-                // } else {
-                //     self.status = VMStatus::OracleWait;
-                //     return VMStatus::OracleWait;
-                // }
                 let mut num_output_values = 0;
                 for oracle_output in data.clone().outputs {
                     match oracle_output {

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -112,7 +112,7 @@ pub struct OracleData {
     /// Input values
     pub input_values: Vec<FieldElement>,
     /// Output register
-    pub output: RegisterIndex,
+    pub outputs: Vec<OracleOutput>,
     /// Output values - they are computed by the (external) oracle once the inputs are known
     pub output_values: Vec<FieldElement>,
 }
@@ -121,6 +121,12 @@ pub struct OracleData {
 pub enum OracleInput {
     RegisterMemIndex(RegisterMemIndex),
     Array { start: RegisterMemIndex, length: usize },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OracleOutput {
+    RegisterIndex(RegisterIndex),
+    Array { start: RegisterIndex, length: usize },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

This PR switches oracle output from a single register index to an enum. With only one register index we assume that if an oracle returns multiple complex types these are all flattened into one array and we are currently handling oracle outputs always as an array. This also means we break arrays of size 1 as there is currently an assumption that if there is only one output value supplied to the oracle it must be a single register. We now require someone to differentiate between register and array oracle outptus and have a `Vec<OracleOutput>` as part of OracleData.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
