### PR TITLE
fix!: Oracle output array start as RegisterMemindex

### DIFF
--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -137,8 +137,7 @@ impl VM {
                                 current_value_index += 1
                             }
                             OracleOutput::Array { start, length } => {
-                                let array_id =
-                                    self.registers.get(RegisterMemIndex::Register(start));
+                                let array_id = self.registers.get(start);
                                 let heap = &mut self.memory.entry(array_id).or_default().memory_map;
                                 for (i, value) in data.output_values.iter().enumerate() {
                                     heap.insert(i, (*value).into());
@@ -690,7 +689,8 @@ mod tests {
 
         let oracle_input =
             OracleInput::RegisterMemIndex(RegisterMemIndex::Register(RegisterIndex(0)));
-        let oracle_output = OracleOutput::Array { start: RegisterIndex(3), length: 2 };
+        let oracle_output =
+            OracleOutput::Array { start: RegisterMemIndex::Register(RegisterIndex(3)), length: 2 };
 
         let mut oracle_data = OracleData {
             name: "get_notes".to_owned(),

--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -126,7 +126,7 @@ pub enum OracleInput {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OracleOutput {
     RegisterIndex(RegisterIndex),
-    Array { start: RegisterIndex, length: usize },
+    Array { start: RegisterMemIndex, length: usize },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
