### PR TITLE
chore: deprecate `hash_constraint_system` and  `checksum_constraint_system`

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -231,6 +231,7 @@ pub enum Language {
     PLONKCSat { width: usize },
 }
 
+#[deprecated]
 pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
     let mut bytes = Vec::new();
     cs.write(&mut bytes).expect("could not serialize circuit");
@@ -242,6 +243,7 @@ pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
     hasher.finalize_fixed().into()
 }
 
+#[deprecated]
 pub fn checksum_constraint_system(cs: &Circuit) -> u32 {
     let mut bytes = Vec::new();
     cs.write(&mut bytes).expect("could not serialize circuit");


### PR DESCRIPTION
chore: deprecate

# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

It's not clear to me what benefit having these functions in ACVM gives as we currently don't use either of them and by having these two functions we're being opinionated about which hash functions to use whereas users may want to use others.

If we want to add some knowledge about hashing ACIR then I'd say that we should just implement `Hash` on the `Circuit` struct and leave it at that.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
