### PR TITLE
fix: Remove old reference to Opcode::Call

### DIFF
--- a/brillig_bytecode/src/opcodes.rs
+++ b/brillig_bytecode/src/opcodes.rs
@@ -52,6 +52,9 @@ pub enum Opcode {
     JMP {
         destination: Label,
     },
+    PushStack {
+        source: RegisterMemIndex,
+    },
     // TODO:This is used to call functions and setup things like
     // TODO execution contexts.
     CallBack,
@@ -73,12 +76,6 @@ pub enum Opcode {
         array_id_reg: RegisterMemIndex,
         index: RegisterMemIndex,
     },
-    PushStack {
-        source: RegisterMemIndex,
-    },
-    // PopStack {
-
-    // }
     /// Used if execution fails during evaluation
     Trap,
     /// Hack
@@ -96,7 +93,8 @@ impl Opcode {
             Opcode::JMPIFNOT { .. } => "jmpifnot",
             Opcode::JMPIF { .. } => "jmpif",
             Opcode::JMP { .. } => "jmp",
-            Opcode::Call { .. } => "call",
+            Opcode::PushStack { .. } => "pushstack",
+            Opcode::CallBack => "callback",
             Opcode::Intrinsics => "intrinsics",
             Opcode::Oracle(_) => "oracle",
             Opcode::Mov { .. } => "mov",


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
