### PR TITLE
feat!: require `Backend` to implement `Default` trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -92,7 +92,7 @@ fn first_missing_assignment(
     })
 }
 
-pub trait Backend: SmartContract + ProofSystemCompiler + PartialWitnessGenerator {}
+pub trait Backend: SmartContract + ProofSystemCompiler + PartialWitnessGenerator + Default {}
 
 /// This component will generate the backend specific output for
 /// each OPCODE.

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -318,8 +318,8 @@ mod test {
     };
 
     use crate::{
-        pwg::block::Blocks, Backend, OpcodeResolution, OpcodeResolutionError,
-        PartialWitnessGenerator, PartialWitnessGeneratorStatus,
+        pwg::block::Blocks, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
+        PartialWitnessGeneratorStatus,
     };
 
     struct StubbedPwg;
@@ -405,14 +405,5 @@ mod test {
             .solve(&mut witness_assignments, &mut blocks, next_opcodes_for_solving)
             .expect("should be solvable");
         assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
-    }
-
-    #[test]
-    fn test_backend_object_safety() {
-        // This test doesn't do anything at runtime.
-        // We just want to ensure that the `Backend` trait is object safe and this test will refuse to compile
-        // if this property is broken.
-        #[allow(dead_code)]
-        fn check_object_safety(_backend: Box<dyn Backend>) {}
     }
 }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

In our new merged `acvm-backend-barretenberg` crate, we're implementing the `Backend` trait directly on the `Barretenberg` struct rather than having a separate `Plonk` unit struct which then constructs `Barretenberg` when needed.

https://github.com/noir-lang/aztec_backend/blob/9fed6e52778d993d7742c46bbeec66087958c075/acvm_backend_barretenberg/src/lib.rs#L21-L26

This means that when we're actually using the backend in Nargo we need to construct the struct, i.e we need to call `let backend = Barretenberg::default()` rather than just being able to do `let backend = Plonk`.

Example: https://github.com/noir-lang/noir/commit/ad822e661ce4082ed96f790e8baa2f76d460b9fc

We then want to enforce that this method exists on all backends so it must be included in the trait definition.

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
