### PR TITLE
feat(brillig)!: bitwise operators, shifts, and cleanup for BinaryOp::evaluate

### DIFF
--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -66,10 +66,8 @@ impl BrilligSolver {
                     }
                 }
                 BrilligInputs::Array(id, expr_arr) => {
-                    let id_as_value: Value = Value {
-                        typ: Typ::Field,
-                        inner: FieldElement::from(*id as u128),
-                    };
+                    let id_as_value: Value =
+                        Value { typ: Typ::Field, inner: FieldElement::from(*id as u128) };
                     // Push value of the array id as a register
                     input_register_values.push(id_as_value.into());
 

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -338,7 +338,7 @@ mod tests {
             Registers::load(vec![Value::from(2u128), Value::from(2u128), Value::from(0u128)]);
 
         let equal_cmp_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(1)),
@@ -381,7 +381,7 @@ mod tests {
         let trap_opcode = Opcode::Trap;
 
         let not_equal_cmp_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(1)),
@@ -465,7 +465,7 @@ mod tests {
         ]);
 
         let equal_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(1)),
@@ -473,7 +473,7 @@ mod tests {
         };
 
         let not_equal_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(3)),
@@ -481,7 +481,7 @@ mod tests {
         };
 
         let less_than_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Lt),
             lhs: RegisterMemIndex::Register(RegisterIndex(3)),
             rhs: RegisterMemIndex::Register(RegisterIndex(4)),
@@ -489,7 +489,7 @@ mod tests {
         };
 
         let less_than_equal_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Lte),
             lhs: RegisterMemIndex::Register(RegisterIndex(3)),
             rhs: RegisterMemIndex::Register(RegisterIndex(4)),
@@ -542,7 +542,7 @@ mod tests {
         ]);
 
         let equal_cmp_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(1)),
@@ -563,7 +563,7 @@ mod tests {
         };
 
         let mem_equal_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(4)),
             rhs: RegisterMemIndex::Register(RegisterIndex(5)),
@@ -627,7 +627,7 @@ mod tests {
         ]);
 
         let equal_cmp_opcode = Opcode::BinaryOp {
-            result_type: Typ::Field,
+            result_type: Typ::Unsigned { bit_size: 1 },
             op: BinaryOp::Cmp(Comparison::Eq),
             lhs: RegisterMemIndex::Register(RegisterIndex(0)),
             rhs: RegisterMemIndex::Register(RegisterIndex(1)),


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
