### PR TITLE
fix: prevent `bn254` feature flag always being enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 members = ["acir_field", "acir", "acvm", "stdlib"]
 
 [workspace.package]
-authors = ["The Noir Team <kevtheappdev@gmail.com>"]
+authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"
 license = "MIT"
 rust-version = "1.66"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.66"
 
 [workspace.dependencies]
 acir = { version = "0.9.0", path = "acir" }
-acir_field = { version = "0.9.0", path = "acir_field" }
+acir_field = { version = "0.9.0", path = "acir_field", default-features = false }
 stdlib = { package = "acvm_stdlib", version = "0.9.0", path = "stdlib" }
 
 hex = "0.4.2"

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -26,6 +26,5 @@ ark-ff = { version = "^0.4.0", optional = true, default-features = false }
 cfg-if = "1.0.0"
 
 [features]
-default = ["bn254"]
 bn254 = ["ark-bn254", "ark-ff"]
 bls12_381 = ["ark-bls12-381", "ark-ff"]

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -26,5 +26,6 @@ ark-ff = { version = "^0.4.0", optional = true, default-features = false }
 cfg-if = "1.0.0"
 
 [features]
-bn254 = ["ark-bn254", "ark-ff"]
-bls12_381 = ["ark-bls12-381", "ark-ff"]
+default = ["bn254"]
+bn254 = ["dep:ark-bn254", "dep:ark-ff"]
+bls12_381 = ["dep:ark-bls12-381", "dep:ark-ff"]

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -30,8 +30,8 @@ indexmap = "1.7.0"
 thiserror = "1.0.21"
 
 [features]
-bn254 = ["acir/bn254"]
-bls12_381 = ["acir/bls12_381"]
+bn254 = ["acir/bn254", "stdlib/bn254"]
+bls12_381 = ["acir/bls12_381", "stdlib/bls12_381"]
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -1,9 +1,12 @@
 [package]
 name = "acvm_stdlib"
-version = "0.9.0"
-edition = "2021"
-license = "MIT"
 description = "The ACVM standard library."
+version = "0.9.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -7,4 +7,8 @@ description = "The ACVM standard library."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acir = { version = "0.9.0", path = "../acir", features = ["bn254"] }
+acir.workspace = true
+
+[features]
+bn254 = ["acir/bn254"]
+bls12_381 = ["acir/bls12_381"]


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

Currently we're always turning on the `bn254` field due to default feature flags, this makes it impossible to use any different fields. I've fixed the feature flag setup so that only the field supplied to the `acvm` package gets turned on.

The second commit contains some miscellaneous cleanup of the various toml files.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
