### PR TITLE
fix(brillig): Stall if a Brillig input array is not fully solved

### DIFF
--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -66,11 +66,7 @@ impl BrilligSolver {
                     }
                 }
                 BrilligInputs::Array(id, expr_arr) => {
-                    let id_as_value: Value =
-                        Value { typ: Typ::Field, inner: FieldElement::from(*id as u128) };
-                    // Push value of the array id as a register
-                    input_register_values.push(id_as_value.into());
-
+                    // Attempt to fetch all array input values
                     let mut continue_eval = true;
                     let mut array_heap: BTreeMap<usize, Value> = BTreeMap::new();
                     for (i, expr) in expr_arr.into_iter().enumerate() {
@@ -82,19 +78,26 @@ impl BrilligSolver {
                             break;
                         }
                     }
-                    input_memory.insert(id_as_value, ArrayHeap { memory_map: array_heap });
 
+                    // If an array value is missing exit the input solver and do not insert the array id as an input register
                     if !continue_eval {
                         break;
                     }
+
+                    let id_as_value: Value =
+                        Value { typ: Typ::Field, inner: FieldElement::from(*id as u128) };
+                    // Push value of the array id as a register
+                    input_register_values.push(id_as_value.into());
+
+                    input_memory.insert(id_as_value, ArrayHeap { memory_map: array_heap });
                 }
             }
         }
 
         if input_register_values.len() != brillig.inputs.len() {
-            let jabber_input =
+            let brillig_input =
                 brillig.inputs.last().expect("Infallible: cannot reach this point if no inputs");
-            let expr = match jabber_input {
+            let expr = match brillig_input {
                 BrilligInputs::Simple(expr) => expr,
                 BrilligInputs::Array(_, expr_arr) => {
                     expr_arr.last().expect("Infallible: cannot reach this point if no inputs")


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

When setting brillig inputs the array id was being inserted even if the array values being inserted onto the heap were not fully solved yet by the acvm. This is now changed to check every element of the array to be inserted as initial memory to a brillig function. If an element is missing we stall the brillig and wait for the acvm to solve the witness in question.   

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
