### PR TITLE
feat(acvm)!: implement `hash_to_field_128_security`

### DIFF
--- a/acvm/src/pwg/hash.rs
+++ b/acvm/src/pwg/hash.rs
@@ -3,43 +3,46 @@ use blake2::{Blake2s, Digest};
 use sha2::Sha256;
 use std::collections::BTreeMap;
 
+use crate::{OpcodeResolution, OpcodeResolutionError};
+
+use super::witness_to_value;
+
 pub fn blake2s(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
-) {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     generic_hash_256::<Blake2s>(initial_witness, gadget_call)
 }
 
 pub fn sha256(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
-) {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     generic_hash_256::<Sha256>(initial_witness, gadget_call)
 }
 
 fn generic_hash_256<D: Digest>(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
-) {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     let mut hasher = D::new();
 
-    // For each input in the vector of inputs, check if we have their witness assignments (Can do this outside of match, since they all have inputs)
-    for input_index in gadget_call.inputs.iter() {
-        let witness = &input_index.witness;
-        let num_bits = input_index.num_bits;
+    // Read witness assignments into hasher.
+    for input in gadget_call.inputs.iter() {
+        let witness = input.witness;
+        let num_bits = input.num_bits as usize;
 
-        let witness_assignment = initial_witness.get(witness);
-        let assignment = match witness_assignment {
-            None => panic!("cannot find witness assignment for {witness:?}"),
-            Some(assignment) => assignment,
-        };
-
-        let bytes = assignment.fetch_nearest_bytes(num_bits as usize);
+        let witness_assignment = witness_to_value(initial_witness, witness)?;
+        let bytes = witness_assignment.fetch_nearest_bytes(num_bits);
         hasher.update(bytes);
     }
+
+    // Perform hash and write outputs to witness map.
     let result = hasher.finalize();
     for i in 0..32 {
         initial_witness
             .insert(gadget_call.outputs[i], FieldElement::from_be_bytes_reduce(&[result[i]]));
     }
+
+    Ok(OpcodeResolution::Solved)
 }


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/aztec_backend/pull/138#issuecomment-1522307087

# Description

## Summary of changes

I've pulled down the implementation of `BlackBoxFunc::HashToField128Security` from `aztec_backend`.

The hash implementations in ACVM now use the checked versions of the reading/writing witness values and return a proper `Result<OpcodeResolution, OpcodeResolutionError>` response to be passed back into ACVM.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
