### PR TITLE
feat(acvm)!: Add CommonReferenceString backend trait

### DIFF
--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -29,6 +29,7 @@ k256 = { version = "0.7.2", features = [
 ] }
 indexmap = "1.7.0"
 thiserror = "1.0.21"
+async-trait = "0.1"
 
 [features]
 default = ["bn254"]

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -85,8 +85,8 @@ pub trait CommonReferenceString {
     ///
     /// This function will be called if the common reference string has been cached previously
     /// and the backend can update it if necessary. This may happen if the common reference string
-    /// contains fewer than the number of points needed by the circuit, or any other checks the backend
-    /// must do.
+    /// contains fewer than the number of points needed by the circuit, or fails any other checks the backend
+    /// must perform.
     ///
     /// If the common reference string doesn't need any updates, implementors can return the value passed.
     async fn update_common_reference_string(

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -65,6 +65,11 @@ pub trait Backend:
 {
 }
 
+// Unfortunately, Rust doesn't natively allow async functions in traits yet.
+// So we need to annotate our trait with this macro and backends need to attach the macro to their `impl`.
+//
+// For more details, see https://docs.rs/async-trait/latest/async_trait/
+// and https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/
 #[async_trait]
 pub trait CommonReferenceString {
     /// The Error type returned by failed function calls in the CommonReferenceString trait.


### PR DESCRIPTION
# Related issue(s)

Needed for https://github.com/noir-lang/acvm-backend-barretenberg/issues/160

# Description

## Summary of changes

This requires a `CommonReferenceString` trait for ACVM Backends.

The reason some functions in other traits were modified to take the `common_reference_string` is because backends can have a circular dependency, such that they need to instantiate themselves before they can get the circuit size for a given circuit and the CRS often needs the circuit size to the data it is using. This means we can't do `Backend::new(CRS::new(circuit_size))` and resulted the functions that need a CRS taking it as an argument.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
