### PR TITLE
feat(acir)!: BlackBoxFunc::VerifyProof

### DIFF
--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -65,6 +65,7 @@ impl BlackBoxFunc {
             10 => BlackBoxFunc::XOR,
             11 => BlackBoxFunc::RANGE,
             12 => BlackBoxFunc::Keccak256,
+            13 => BlackBoxFunc::VerifyProof,
             _ => return None,
         };
         Some(function)

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -16,6 +16,7 @@ use acir::{
     native_types::{Expression, Witness},
     BlackBoxFunc,
 };
+use k256::elliptic_curve::Field;
 use pwg::{block::Blocks, directives::solve_directives};
 use std::collections::BTreeMap;
 use thiserror::Error;
@@ -236,6 +237,17 @@ pub trait ProofSystemCompiler {
         circuit: &Circuit,
         verification_key: &[u8],
     ) -> bool;
+
+    fn proof_as_fields(
+        &self,
+        proof: &[u8],
+        public_inputs: BTreeMap<Witness, FieldElement>,
+    ) -> Vec<FieldElement>;
+
+    fn vk_as_fields(
+        &self,
+        verification_key: &[u8],
+    ) -> (Vec<FieldElement>, FieldElement);
 }
 
 /// Supported NP complete languages

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -244,10 +244,7 @@ pub trait ProofSystemCompiler {
         public_inputs: BTreeMap<Witness, FieldElement>,
     ) -> Vec<FieldElement>;
 
-    fn vk_as_fields(
-        &self,
-        verification_key: &[u8],
-    ) -> (Vec<FieldElement>, FieldElement);
+    fn vk_as_fields(&self, verification_key: &[u8]) -> (Vec<FieldElement>, FieldElement);
 }
 
 /// Supported NP complete languages


### PR DESCRIPTION
# Related issue(s)

Resolves #198 

# Description

Add VerifyProof variant to BlackBoxFunc enum

## Summary of changes

This will be used by backends looking to integrate recursion. As per the issue discussion, this requires enabling the OutputSize of FuncDefinition's to be Variable. I left the `InputSize` and `OutputSize` enums distinct for now and left a comment under what scenarios OutputSize can be Variable. The OutputSize is NOT dependent upon the user inputs (like the input size to sha256 for example), but rather dependent upon the proving system that is integrating with ACVM. This distinction is important as this change to variable output size does imply support for dynamic circuits. 

I will make an issue to consider how we can best differentiate whether the variable OutputSize can be dependent upon a gadget's input. It might need to be in this PR though where we have a function in the ProofSystemCompiler similar to `black_box_function_supported` that can output a BlackBoxFunc's proof system dependent OutputSize. Opening this PR as part of the discussion. 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
