### PR TITLE
feat(acvm)!: have all black box functions return `Result<OpcodeResolution, OpcodeResolutionError>`

### DIFF
--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -1,12 +1,12 @@
 use super::{directives::insert_witness, witness_to_value};
-use crate::OpcodeResolutionError;
+use crate::{OpcodeResolution, OpcodeResolutionError};
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
 use std::collections::BTreeMap;
 
 pub fn solve_logic_opcode(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     func_call: &BlackBoxFuncCall,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     match func_call.name {
         BlackBoxFunc::AND => LogicSolver::solve_and_gate(initial_witness, func_call),
         BlackBoxFunc::XOR => LogicSolver::solve_xor_gate(initial_witness, func_call),
@@ -25,7 +25,7 @@ impl LogicSolver {
         result: Witness,
         num_bits: u32,
         is_xor_gate: bool,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         let w_l_value = witness_to_value(initial_witness, *a)?;
         let w_r_value = witness_to_value(initial_witness, *b)?;
 
@@ -35,20 +35,20 @@ impl LogicSolver {
             w_l_value.and(w_r_value, num_bits)
         };
         insert_witness(result, assignment, initial_witness)?;
-        Ok(())
+        Ok(OpcodeResolution::Solved)
     }
 
     pub fn solve_and_gate(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gate: &BlackBoxFuncCall,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         let (a, b, result, num_bits) = extract_input_output(gate);
         LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, false)
     }
     pub fn solve_xor_gate(
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         gate: &BlackBoxFuncCall,
-    ) -> Result<(), OpcodeResolutionError> {
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         let (a, b, result, num_bits) = extract_input_output(gate);
         LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, true)
     }

--- a/acvm/src/pwg/signature/ecdsa.rs
+++ b/acvm/src/pwg/signature/ecdsa.rs
@@ -1,12 +1,12 @@
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, FieldElement};
 use std::collections::BTreeMap;
 
-use crate::{pwg::witness_to_value, OpcodeResolutionError};
+use crate::{pwg::witness_to_value, OpcodeResolution, OpcodeResolutionError};
 
 pub fn secp256k1_prehashed(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     gadget_call: &BlackBoxFuncCall,
-) -> Result<(), OpcodeResolutionError> {
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
     let mut inputs_iter = gadget_call.inputs.iter();
 
     let mut pub_key_x = [0u8; 32];
@@ -50,13 +50,8 @@ pub fn secp256k1_prehashed(
         ecdsa_secp256k1::verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature)
             .is_ok();
 
-    let result = match result {
-        true => FieldElement::one(),
-        false => FieldElement::zero(),
-    };
-
-    initial_witness.insert(gadget_call.outputs[0], result);
-    Ok(())
+    initial_witness.insert(gadget_call.outputs[0], FieldElement::from(result));
+    Ok(OpcodeResolution::Solved)
 }
 
 mod ecdsa_secp256k1 {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

For consistency, all bb function implementations inside ACVM pass back a `Result<OpcodeResolution, OpcodeResolutionError>` so backends don't need to do anything other than forward the return value back into the ACVM.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
