### PR TITLE
fix(acir): add `bn254` as default feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 rust-version = "1.66"
 
 [workspace.dependencies]
-acir = { version = "0.10.0", path = "acir" }
+acir = { version = "0.10.0", path = "acir", default-features = false }
 acir_field = { version = "0.10.0", path = "acir_field", default-features = false }
 stdlib = { package = "acvm_stdlib", version = "0.10.0", path = "stdlib" }
 

--- a/acir/Cargo.toml
+++ b/acir/Cargo.toml
@@ -22,5 +22,6 @@ strum = "0.24"
 strum_macros = "0.24"
 
 [features]
+default = ["bn254"]
 bn254 = ["acir_field/bn254"]
 bls12_381 = ["acir_field/bls12_381"]


### PR DESCRIPTION
# Related issue(s)

Resolves [(CI failure)](https://github.com/noir-lang/acvm/actions/runs/4830288705/jobs/8606331047)

# Description

## Summary of changes

We currently can't publish releases as `cargo publish` builds each package before publication and `acir` doesn't build without a feature flag being set (this wasn't encountered in real usage as we always set this flag when building in the context of the workspace/noir).

See: https://github.com/noir-lang/acvm/actions/runs/4830288705/jobs/8606331047

This PR sets a default feature flag so that `cargo publish` can build the `acir` crate in isolation.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
