### PR TITLE
fix(acvm_stdlib): add default flag for fields in `acvm_stdlib`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.66"
 [workspace.dependencies]
 acir = { version = "0.10.1", path = "acir", default-features = false }
 acir_field = { version = "0.10.1", path = "acir_field", default-features = false }
-stdlib = { package = "acvm_stdlib", version = "0.10.1", path = "stdlib" }
+stdlib = { package = "acvm_stdlib", version = "0.10.1", path = "stdlib", default-features = false }
 
 hex = "0.4.2"
 num-bigint = "0.4"

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -13,5 +13,6 @@ rust-version.workspace = true
 acir.workspace = true
 
 [features]
+default = ["bn254"]
 bn254 = ["acir/bn254"]
 bls12_381 = ["acir/bls12_381"]


### PR DESCRIPTION
Followup to https://github.com/noir-lang/acvm/pull/240