### PR TITLE
chore(ci): perform a dry-run release on release-please PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,17 @@
 name: Publish crates
 
 on:
+  push:
+    # We only want this to perform dry runs on the release PR.
+    branches: ["release-please--branches--master"]
   workflow_dispatch:
     inputs:
       acvm-ref:
         description: The acvm reference to checkout
+        required: true
+      publish:
+        description: Publish packages to crates.io
+        type: boolean
         required: true
 
 jobs:
@@ -15,7 +22,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.acvm-ref }}
+          ref: ${{ inputs.acvm-ref || github.ref }}
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@master
@@ -25,25 +32,29 @@ jobs:
       # These steps are in a specific order so crate dependencies are updated first
       - name: Publish acir_field
         run: |
-          cargo publish --package acir_field
+          cargo publish $DRY_RUN_FLAG --package acir_field
         env:
+          DRY_RUN_FLAG: ${{ (inputs.publish && "") || "--dry-run" }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
 
       - name: Publish acir
         run: |
-          cargo publish --package acir
+          cargo publish $DRY_RUN_FLAG --package acir
         env:
+          DRY_RUN_FLAG: ${{ (inputs.publish && "") || "--dry-run" }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
 
       - name: Publish acvm_stdlib
         run: |
-          cargo publish --package acvm_stdlib
+          cargo publish $DRY_RUN_FLAG --package acvm_stdlib
         env:
+          DRY_RUN_FLAG: ${{ (inputs.publish && "") || "--dry-run" }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
 
       - name: Publish acvm
         run: |
-          cargo publish --package acvm
+          cargo publish $DRY_RUN_FLAG --package acvm
         env:
+          DRY_RUN_FLAG: ${{ (inputs.publish && "") || "--dry-run" }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.ACVM_CRATES_IO_TOKEN }}
   

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           workflow: publish.yml
           ref: master
-          inputs: '{ "acvm-ref": "${{ needs.release-please.outputs.tag-name }}" }'
+          inputs: '{ "acvm-ref": "${{ needs.release-please.outputs.tag-name }}", "publish": true }'


### PR DESCRIPTION
# Related issue(s)

Resolves #241 

# Description

## Summary of changes

This PR runs the `publish` workflow on pushes to the branch which release-please uses to ensure that the release will be successful. To prevent these CI runs from publishing to crates.io we require a `publish` flag to be set when calling the workflow to not run `cargo publish --dry-run` 

I haven't performed any testing of this on a separate repo.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
