### PR TITLE
chore: move `hex` and `blake2` deps down into crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,7 @@ acir = { version = "0.10.3", path = "acir", default-features = false }
 acir_field = { version = "0.10.3", path = "acir_field", default-features = false }
 stdlib = { package = "acvm_stdlib", version = "0.10.3", path = "stdlib", default-features = false }
 
-hex = "0.4.2"
 num-bigint = "0.4"
 num-traits = "0.2"
-
-blake2 = "0.9.1"
 
 serde = { version = "1.0.136", features = ["derive"] }

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -10,10 +10,9 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-hex.workspace = true
+hex = "0.4.2"
 num-bigint.workspace = true
 serde.workspace = true
-
 
 ark-bn254 = { version = "^0.4.0", optional = true, default-features = false, features = [
     "curve",

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -12,11 +12,11 @@ rust-version.workspace = true
 [dependencies]
 num-bigint.workspace = true
 num-traits.workspace = true
-blake2.workspace = true
 
 acir.workspace = true
 stdlib.workspace = true
 
+blake2 = "0.9.1"
 sha2 = "0.9.3"
 crc32fast = "1.3.2"
 k256 = { version = "0.7.2", features = [


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

These dependencies are only used in a single crate so I've moved them down to be defined there.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
