### PR TITLE
feat(acvm): Add generic error for failing to solve an opcode

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -52,7 +52,7 @@ pub enum OpcodeResolutionError {
     UnexpectedOpcode(&'static str, BlackBoxFunc),
     #[error("expected {0} inputs for function {1}, but got {2}")]
     IncorrectNumFunctionArguments(usize, BlackBoxFunc, usize),
-    #[error("failed to solve blackbox function: {0}, reason: {1}")] 
+    #[error("failed to solve blackbox function: {0}, reason: {1}")]
     BlackBoxFunctionFailed(BlackBoxFunc, String),
 }
 

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -52,6 +52,8 @@ pub enum OpcodeResolutionError {
     UnexpectedOpcode(&'static str, BlackBoxFunc),
     #[error("expected {0} inputs for function {1}, but got {2}")]
     IncorrectNumFunctionArguments(usize, BlackBoxFunc, usize),
+    #[error("opcode solve failed: {0}")]
+    OpcodeSolveFailed(String),
 }
 
 #[derive(Debug, PartialEq)]

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -52,8 +52,8 @@ pub enum OpcodeResolutionError {
     UnexpectedOpcode(&'static str, BlackBoxFunc),
     #[error("expected {0} inputs for function {1}, but got {2}")]
     IncorrectNumFunctionArguments(usize, BlackBoxFunc, usize),
-    #[error("opcode solve failed: {0}")]
-    OpcodeSolveFailed(String),
+    #[error("failed to solve blackbox function: {0}, reason: {1}")] 
+    BlackBoxFunctionFailed(BlackBoxFunc, String),
 }
 
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
# Related issue(s)

Resolves (link to issue)

# Description

## Summary of changes

This adds a generic `OpcodeSolveFailed` error to the `OpcodeNotSolvable` error enum so backends can report other problems with solving an opcode. I encountered this problem when converting aztec_backend to the fallible traits.

I think the data carried still needs to be bikeshed, since only an error string is probably not enough information.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
