### PR TITLE
chore(acvm): Remove usage of `insert_witness` with `insert_value`

### DIFF
--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -10,7 +10,7 @@ use crate::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
 
 use super::{
     arithmetic::{ArithmeticSolver, GateStatus},
-    directives::insert_witness,
+    insert_value,
 };
 
 /// Maps a block to its emulated state
@@ -83,7 +83,7 @@ impl BlockSolver {
                     GateStatus::GateSolvable(sum, (coef, w)) => {
                         let map_value =
                             self.get_value(index).ok_or_else(|| missing_assignment(Some(w)))?;
-                        insert_witness(w, (map_value - sum - value.q_c) / coef, initial_witness)?;
+                        insert_value(&w, (map_value - sum - value.q_c) / coef, initial_witness)?;
                     }
                     GateStatus::GateSatisfied(sum) => {
                         self.insert_value(index, sum + value.q_c);
@@ -131,7 +131,7 @@ mod test {
         FieldElement,
     };
 
-    use crate::pwg::directives::insert_witness;
+    use crate::pwg::insert_value;
 
     use super::Blocks;
 
@@ -163,11 +163,11 @@ mod test {
         let id = BlockId::default();
         let mut initial_witness = BTreeMap::new();
         let mut value = FieldElement::zero();
-        insert_witness(Witness(1), value, &mut initial_witness).unwrap();
+        insert_value(&Witness(1), value, &mut initial_witness).unwrap();
         value = FieldElement::one();
-        insert_witness(Witness(2), value, &mut initial_witness).unwrap();
+        insert_value(&Witness(2), value, &mut initial_witness).unwrap();
         value = value + value;
-        insert_witness(Witness(3), value, &mut initial_witness).unwrap();
+        insert_value(&Witness(3), value, &mut initial_witness).unwrap();
         let mut blocks = Blocks::default();
         blocks.solve(id, &trace, &mut initial_witness).unwrap();
         assert_eq!(initial_witness[&Witness(4)], FieldElement::one());

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -61,13 +61,13 @@ fn solve_directives_internal(
                 (&int_a % &int_b, &int_a / &int_b)
             };
 
-            insert_witness(
-                *q,
+            insert_value(
+                q,
                 FieldElement::from_be_bytes_reduce(&int_q.to_bytes_be()),
                 initial_witness,
             )?;
-            insert_witness(
-                *r,
+            insert_value(
+                r,
                 FieldElement::from_be_bytes_reduce(&int_r.to_bytes_be()),
                 initial_witness,
             )?;
@@ -129,7 +129,7 @@ fn solve_directives_internal(
             let control = route(base, b);
             for (w, value) in bits.iter().zip(control) {
                 let value = if value { FieldElement::one() } else { FieldElement::zero() };
-                insert_witness(*w, value, initial_witness)?;
+                insert_value(w, value, initial_witness)?;
             }
             Ok(())
         }
@@ -170,24 +170,6 @@ fn solve_directives_internal(
             Ok(())
         }
     }
-}
-
-pub fn insert_witness(
-    w: Witness,
-    value: FieldElement,
-    initial_witness: &mut BTreeMap<Witness, FieldElement>,
-) -> Result<(), OpcodeResolutionError> {
-    match initial_witness.entry(w) {
-        std::collections::btree_map::Entry::Vacant(e) => {
-            e.insert(value);
-        }
-        std::collections::btree_map::Entry::Occupied(e) => {
-            if e.get() != &value {
-                return Err(OpcodeResolutionError::UnsatisfiedConstrain);
-            }
-        }
-    }
-    Ok(())
 }
 
 /// This trims any leading zeroes.

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -1,4 +1,4 @@
-use super::{directives::insert_witness, witness_to_value};
+use super::{insert_value, witness_to_value};
 use crate::{OpcodeResolution, OpcodeResolutionError};
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
 use std::collections::BTreeMap;
@@ -34,7 +34,7 @@ impl LogicSolver {
         } else {
             w_l_value.and(w_r_value, num_bits)
         };
-        insert_witness(result, assignment, initial_witness)?;
+        insert_value(&result, assignment, initial_witness)?;
         Ok(OpcodeResolution::Solved)
     }
 

--- a/acvm/src/pwg/oracle.rs
+++ b/acvm/src/pwg/oracle.rs
@@ -4,7 +4,7 @@ use acir::{circuit::opcodes::OracleData, native_types::Witness, FieldElement};
 
 use crate::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
 
-use super::{arithmetic::ArithmeticSolver, directives::insert_witness};
+use super::{arithmetic::ArithmeticSolver, insert_value};
 
 pub struct OracleSolver;
 
@@ -28,7 +28,7 @@ impl OracleSolver {
         if data.input_values.len() == data.inputs.len() {
             if data.output_values.len() == data.outputs.len() {
                 for (out, value) in data.outputs.iter().zip(data.output_values.iter()) {
-                    insert_witness(*out, *value, initial_witness)?;
+                    insert_value(out, *value, initial_witness)?;
                 }
                 Ok(OpcodeResolution::Solved)
             } else {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

We currently have the functions [`insert_value`](https://github.com/noir-lang/acvm/blob/45c45f7cdb79c3ccb0373ca0e698b282d4dabc39/acvm/src/pwg.rs#L59-L76) and [`insert_witness`](https://github.com/noir-lang/acvm/blob/45c45f7cdb79c3ccb0373ca0e698b282d4dabc39/acvm/src/pwg/directives.rs#L175-L191). These are both almost identical, the only different being that `insert_value` with update the witness map before returning an `UnsatisfiedConstrain` error whereas `insert_witness` doesn't.

This difference is near meaningless (and if we decided that we wanted one behaviour in particular then we should be consistent with it) so there's no point in maintaining both functions. I've then removed `insert_witness`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
