### PR TITLE
fix(acir): Fix `Expression` multiplication to correctly handle degree 1 terms

### DIFF
--- a/acir/src/native_types/expression/operators.rs
+++ b/acir/src/native_types/expression/operators.rs
@@ -222,3 +222,63 @@ fn single_mul(w: Witness, b: &Expression) -> Expression {
         ..Default::default()
     }
 }
+
+#[test]
+fn add_smoketest() {
+    let a = Expression {
+        mul_terms: vec![],
+        linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
+        q_c: FieldElement::from(2u128),
+    };
+
+    let b = Expression {
+        mul_terms: vec![],
+        linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
+        q_c: FieldElement::one(),
+    };
+
+    assert_eq!(
+        &a + &b,
+        Expression {
+            mul_terms: vec![],
+            linear_combinations: vec![
+                (FieldElement::from(2u128), Witness(2)),
+                (FieldElement::from(4u128), Witness(4))
+            ],
+            q_c: FieldElement::from(3u128)
+        }
+    );
+
+    // Enforce commutativity
+    assert_eq!(&a + &b, &b + &a);
+}
+
+#[test]
+fn mul_smoketest() {
+    let a = Expression {
+        mul_terms: vec![],
+        linear_combinations: vec![(FieldElement::from(2u128), Witness(2))],
+        q_c: FieldElement::from(2u128),
+    };
+
+    let b = Expression {
+        mul_terms: vec![],
+        linear_combinations: vec![(FieldElement::from(4u128), Witness(4))],
+        q_c: FieldElement::one(),
+    };
+
+    assert_eq!(
+        &a * &b,
+        Expression {
+            mul_terms: vec![(FieldElement::from(8u128), Witness(2), Witness(4)),],
+            linear_combinations: vec![
+                (FieldElement::from(2u128), Witness(2)),
+                (FieldElement::from(8u128), Witness(4))
+            ],
+            q_c: FieldElement::from(2u128)
+        }
+    );
+
+    // Enforce commutativity
+    assert_eq!(&a * &b, &b * &a);
+}

--- a/acir/src/native_types/expression/operators.rs
+++ b/acir/src/native_types/expression/operators.rs
@@ -195,12 +195,18 @@ impl Mul<&Expression> for &Expression {
         }
         while i1 < self.linear_combinations.len() {
             let (a_c, a_w) = self.linear_combinations[i1];
-            output.linear_combinations.push((rhs.q_c * a_c, a_w));
+            let coeff = rhs.q_c * a_c;
+            if !coeff.is_zero() {
+                output.linear_combinations.push((coeff, a_w));
+            }
             i1 += 1;
         }
         while i2 < rhs.linear_combinations.len() {
             let (b_c, b_w) = rhs.linear_combinations[i2];
-            output.linear_combinations.push((self.q_c * b_c, b_w));
+            let coeff = self.q_c * b_c;
+            if !coeff.is_zero() {
+                output.linear_combinations.push((coeff, b_w));
+            }
             i2 += 1;
         }
 

--- a/acir/src/native_types/expression/operators.rs
+++ b/acir/src/native_types/expression/operators.rs
@@ -199,7 +199,7 @@ impl Mul<&Expression> for &Expression {
             i1 += 1;
         }
         while i2 < rhs.linear_combinations.len() {
-            let (b_c, b_w) = rhs.linear_combinations[i1];
+            let (b_c, b_w) = rhs.linear_combinations[i2];
             output.linear_combinations.push((self.q_c * b_c, b_w));
             i2 += 1;
         }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

There was a typo in the implementation of the `Mul` operator for `Expressions`. 

https://github.com/noir-lang/acvm/blob/45c45f7cdb79c3ccb0373ca0e698b282d4dabc39/acir/src/native_types/expression/operators.rs#L196-L205

Both of these while-loops use `i1` to index into `linear_combinations` while the second should use `i2`. This results in either improper multiplication or panics when trying to read past the end of `rhs.linear_combinations`.

I've written a quick smoke test for the `Mul` operator along with another for `Add` (which was already covered by the smoketest for `add_mul`. The first commit shows this test catching the error and it is fixed in later commits.

I've also added an extra bit of logic to avoid zero-coefficient terms when multiplying `Expressions` together.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
