### PR TITLE
feat!: Remove `solve` from PWG trait & introduce separate solvers for each blackbox

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -7,16 +7,14 @@
 pub mod compiler;
 pub mod pwg;
 
-use crate::pwg::{arithmetic::ArithmeticSolver, oracle::OracleSolver};
 use acir::{
     circuit::{
-        opcodes::{BlackBoxFuncCall, OracleData},
+        opcodes::{BlackBoxFuncCall, FunctionInput},
         Circuit, Opcode,
     },
     native_types::{Expression, Witness},
     BlackBoxFunc,
 };
-use pwg::{block::Blocks, directives::solve_directives};
 use std::collections::BTreeMap;
 use thiserror::Error;
 
@@ -54,144 +52,90 @@ pub enum OpcodeResolutionError {
     IncorrectNumFunctionArguments(usize, BlackBoxFunc, usize),
 }
 
-#[derive(Debug, PartialEq)]
-pub enum OpcodeResolution {
-    /// The opcode is resolved
-    Solved,
-    /// The opcode is not solvable
-    Stalled(OpcodeNotSolvable),
-    /// The opcode is not solvable but could resolved some witness
-    InProgress,
-}
-
-#[derive(Debug, PartialEq)]
-pub enum PartialWitnessGeneratorStatus {
-    /// All opcodes have been solved.
-    Solved,
-
-    /// The `PartialWitnessGenerator` has encountered a request for [oracle data][Opcode::Oracle].
-    ///
-    /// The caller must resolve these opcodes externally and insert the results into the intermediate witness.
-    /// Once this is done, the `PartialWitnessGenerator` can be restarted to solve the remaining opcodes.
-    RequiresOracleData { required_oracle_data: Vec<OracleData>, unsolved_opcodes: Vec<Opcode> },
-}
-
-/// Check if all of the inputs to the function have assignments
-///
-/// Returns the first missing assignment if any are missing
-fn first_missing_assignment(
-    witness_assignments: &BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
-) -> Option<Witness> {
-    func_call.inputs.iter().find_map(|input| {
-        if witness_assignments.contains_key(&input.witness) {
-            None
-        } else {
-            Some(input.witness)
-        }
-    })
-}
-
 pub trait Backend: SmartContract + ProofSystemCompiler + PartialWitnessGenerator + Default {}
 
 /// This component will generate the backend specific output for
 /// each OPCODE.
 /// Returns an Error if the backend does not support that OPCODE
 pub trait PartialWitnessGenerator {
-    fn solve(
+    fn aes(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        blocks: &mut Blocks,
-        mut opcode_to_solve: Vec<Opcode>,
-    ) -> Result<PartialWitnessGeneratorStatus, OpcodeResolutionError> {
-        let mut unresolved_opcodes: Vec<Opcode> = Vec::new();
-        let mut unresolved_oracles: Vec<OracleData> = Vec::new();
-        while !opcode_to_solve.is_empty() || !unresolved_oracles.is_empty() {
-            unresolved_opcodes.clear();
-            let mut stalled = true;
-            let mut opcode_not_solvable = None;
-            for opcode in &opcode_to_solve {
-                let mut solved_oracle_data = None;
-                let resolution = match opcode {
-                    Opcode::Arithmetic(expr) => ArithmeticSolver::solve(initial_witness, expr),
-                    Opcode::BlackBoxFuncCall(bb_func) => {
-                        if let Some(unassigned_witness) =
-                            first_missing_assignment(initial_witness, bb_func)
-                        {
-                            Ok(OpcodeResolution::Stalled(OpcodeNotSolvable::MissingAssignment(
-                                unassigned_witness.0,
-                            )))
-                        } else {
-                            self.solve_black_box_function_call(initial_witness, bb_func)
-                        }
-                    }
-                    Opcode::Directive(directive) => solve_directives(initial_witness, directive),
-                    Opcode::Block(block) | Opcode::ROM(block) | Opcode::RAM(block) => {
-                        blocks.solve(block.id, &block.trace, initial_witness)
-                    }
-                    Opcode::Oracle(data) => {
-                        let mut data_clone = data.clone();
-                        let result = OracleSolver::solve(initial_witness, &mut data_clone)?;
-                        solved_oracle_data = Some(data_clone);
-                        Ok(result)
-                    }
-                };
-                match resolution {
-                    Ok(OpcodeResolution::Solved) => {
-                        stalled = false;
-                    }
-                    Ok(OpcodeResolution::InProgress) => {
-                        stalled = false;
-                        // InProgress Oracles must be externally re-solved
-                        if let Some(oracle) = solved_oracle_data {
-                            unresolved_oracles.push(oracle);
-                        } else {
-                            unresolved_opcodes.push(opcode.clone());
-                        }
-                    }
-                    Ok(OpcodeResolution::Stalled(not_solvable)) => {
-                        if opcode_not_solvable.is_none() {
-                            // we keep track of the first unsolvable opcode
-                            opcode_not_solvable = Some(not_solvable);
-                        }
-                        // We push those opcodes not solvable to the back as
-                        // it could be because the opcodes are out of order, i.e. this assignment
-                        // relies on a later opcodes' results
-                        unresolved_opcodes.push(match solved_oracle_data {
-                            Some(oracle_data) => Opcode::Oracle(oracle_data),
-                            None => opcode.clone(),
-                        });
-                    }
-                    Err(OpcodeResolutionError::OpcodeNotSolvable(_)) => {
-                        unreachable!("ICE - Result should have been converted to GateResolution")
-                    }
-                    Err(err) => return Err(err),
-                }
-            }
-            // We have oracles that must be externally resolved
-            if !unresolved_oracles.is_empty() {
-                return Ok(PartialWitnessGeneratorStatus::RequiresOracleData {
-                    required_oracle_data: unresolved_oracles,
-                    unsolved_opcodes: unresolved_opcodes,
-                });
-            }
-            // We are stalled because of an opcode being bad
-            if stalled && !unresolved_opcodes.is_empty() {
-                return Err(OpcodeResolutionError::OpcodeNotSolvable(
-                    opcode_not_solvable
-                        .expect("infallible: cannot be stalled and None at the same time"),
-                ));
-            }
-            std::mem::swap(&mut opcode_to_solve, &mut unresolved_opcodes);
-        }
-        Ok(PartialWitnessGeneratorStatus::Solved)
-    }
-
-    fn solve_black_box_function_call(
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn and(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        func_call: &BlackBoxFuncCall,
-    ) -> Result<OpcodeResolution, OpcodeResolutionError>;
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn xor(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn range(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn sha256(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn blake2s(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn compute_merkle_root(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn schnorr_verify(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn pedersen(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn hash_to_field128_security(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn ecdsa_secp256k1(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn fixed_base_scalar_mul(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+    fn keccak256(
+        &self,
+        initial_witness: &mut BTreeMap<Witness, FieldElement>,
+        inputs: &Vec<FunctionInput>,
+        outputs: &Vec<Witness>,
+    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
 }
 
 pub trait SmartContract {
@@ -316,7 +260,7 @@ mod test {
     use acir::{
         circuit::{
             directives::Directive,
-            opcodes::{BlackBoxFuncCall, OracleData},
+            opcodes::{FunctionInput, OracleData},
             Opcode,
         },
         native_types::{Expression, Witness},
@@ -324,19 +268,142 @@ mod test {
     };
 
     use crate::{
-        pwg::block::Blocks, OpcodeResolution, OpcodeResolutionError, PartialWitnessGenerator,
-        PartialWitnessGeneratorStatus,
+        pwg::{self, block::Blocks, OpcodeResolution, PartialWitnessGeneratorStatus},
+        OpcodeResolutionError, PartialWitnessGenerator,
     };
 
     struct StubbedPwg;
 
     impl PartialWitnessGenerator for StubbedPwg {
-        fn solve_black_box_function_call(
+        fn aes(
             &self,
-            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            _func_call: &BlackBoxFuncCall,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn and(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn xor(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn range(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn sha256(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn blake2s(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn compute_merkle_root(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn schnorr_verify(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn pedersen(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn hash_to_field128_security(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn ecdsa_secp256k1(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn fixed_base_scalar_mul(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
+        }
+        fn keccak256(
+            &self,
+            initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            inputs: &Vec<FunctionInput>,
+            outputs: &Vec<Witness>,
+        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+            {
+                panic!("Path not trodden by this test")
+            }
         }
     }
 
@@ -384,15 +451,14 @@ mod test {
             }),
         ];
 
-        let pwg = StubbedPwg;
+        let backend = StubbedPwg;
 
         let mut witness_assignments = BTreeMap::from([
             (Witness(1), FieldElement::from(2u128)),
             (Witness(2), FieldElement::from(3u128)),
         ]);
         let mut blocks = Blocks::default();
-        let solver_status = pwg
-            .solve(&mut witness_assignments, &mut blocks, opcodes)
+        let solver_status = pwg::solve(backend, &mut witness_assignments, &mut blocks, opcodes)
             .expect("should stall on oracle");
         let PartialWitnessGeneratorStatus::RequiresOracleData { mut required_oracle_data, unsolved_opcodes } = solver_status else {
             panic!("Should require oracle data")

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -61,80 +61,80 @@ pub trait PartialWitnessGenerator {
     fn aes(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn and(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn xor(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn range(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn sha256(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn blake2s(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn compute_merkle_root(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn schnorr_verify(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn pedersen(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn hash_to_field128_security(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn ecdsa_secp256k1(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn fixed_base_scalar_mul(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn keccak256(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        inputs: &Vec<FunctionInput>,
-        outputs: &Vec<Witness>,
+        inputs: &[FunctionInput],
+        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
 }
 
@@ -277,9 +277,9 @@ mod test {
     impl PartialWitnessGenerator for StubbedPwg {
         fn aes(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -287,9 +287,9 @@ mod test {
         }
         fn and(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -297,9 +297,9 @@ mod test {
         }
         fn xor(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -307,9 +307,9 @@ mod test {
         }
         fn range(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -317,9 +317,9 @@ mod test {
         }
         fn sha256(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -327,9 +327,9 @@ mod test {
         }
         fn blake2s(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -337,9 +337,9 @@ mod test {
         }
         fn compute_merkle_root(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -347,9 +347,9 @@ mod test {
         }
         fn schnorr_verify(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -357,9 +357,9 @@ mod test {
         }
         fn pedersen(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -367,9 +367,9 @@ mod test {
         }
         fn hash_to_field128_security(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -377,9 +377,9 @@ mod test {
         }
         fn ecdsa_secp256k1(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -387,9 +387,9 @@ mod test {
         }
         fn fixed_base_scalar_mul(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -397,9 +397,9 @@ mod test {
         }
         fn keccak256(
             &self,
-            initial_witness: &mut BTreeMap<Witness, FieldElement>,
-            inputs: &Vec<FunctionInput>,
-            outputs: &Vec<Witness>,
+            _initial_witness: &mut BTreeMap<Witness, FieldElement>,
+            _inputs: &[FunctionInput],
+            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")
@@ -458,7 +458,7 @@ mod test {
             (Witness(2), FieldElement::from(3u128)),
         ]);
         let mut blocks = Blocks::default();
-        let solver_status = pwg::solve(backend, &mut witness_assignments, &mut blocks, opcodes)
+        let solver_status = pwg::solve(&backend, &mut witness_assignments, &mut blocks, opcodes)
             .expect("should stall on oracle");
         let PartialWitnessGeneratorStatus::RequiresOracleData { mut required_oracle_data, unsolved_opcodes } = solver_status else {
             panic!("Should require oracle data")
@@ -473,9 +473,9 @@ mod test {
         oracle_data.output_values = vec![oracle_data.input_values.last().unwrap().inverse()];
         let mut next_opcodes_for_solving = vec![Opcode::Oracle(oracle_data)];
         next_opcodes_for_solving.extend_from_slice(&unsolved_opcodes[..]);
-        let solver_status = pwg
-            .solve(&mut witness_assignments, &mut blocks, next_opcodes_for_solving)
-            .expect("should be solvable");
+        let solver_status =
+            pwg::solve(&backend, &mut witness_assignments, &mut blocks, next_opcodes_for_solving)
+                .expect("should be solvable");
         assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
     }
 }

--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -52,7 +52,7 @@ pub enum OpcodeResolution {
 /// Returns the first missing assignment if any are missing
 fn first_missing_assignment(
     witness_assignments: &BTreeMap<Witness, FieldElement>,
-    inputs: &Vec<FunctionInput>,
+    inputs: &[FunctionInput],
 ) -> Option<Witness> {
     inputs.iter().find_map(|input| {
         if witness_assignments.contains_key(&input.witness) {
@@ -65,13 +65,13 @@ fn first_missing_assignment(
 
 fn is_stalled(
     witness_assignments: &BTreeMap<Witness, FieldElement>,
-    inputs: &Vec<FunctionInput>,
+    inputs: &[FunctionInput],
 ) -> bool {
     inputs.iter().all(|input| witness_assignments.contains_key(&input.witness))
 }
 
 pub fn solve(
-    backend: impl PartialWitnessGenerator,
+    backend: &impl PartialWitnessGenerator,
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
     blocks: &mut Blocks,
     mut opcode_to_solve: Vec<Opcode>,

--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -1,13 +1,16 @@
 // Re-usable methods that backends can use to implement their PWG
 
-use crate::{OpcodeNotSolvable, OpcodeResolutionError};
+use crate::{OpcodeNotSolvable, OpcodeResolutionError, PartialWitnessGenerator};
 use acir::{
+    circuit::opcodes::{BlackBoxFuncCall, FunctionInput, Opcode, OracleData},
     native_types::{Expression, Witness},
-    FieldElement,
+    BlackBoxFunc, FieldElement,
 };
 use std::collections::BTreeMap;
 
-use self::arithmetic::ArithmeticSolver;
+use self::{
+    arithmetic::ArithmeticSolver, block::Blocks, directives::solve_directives, oracle::OracleSolver,
+};
 
 // arithmetic
 pub mod arithmetic;
@@ -21,6 +24,209 @@ pub mod oracle;
 pub mod range;
 pub mod signature;
 pub mod sorting;
+
+#[derive(Debug, PartialEq)]
+pub enum PartialWitnessGeneratorStatus {
+    /// All opcodes have been solved.
+    Solved,
+
+    /// The `PartialWitnessGenerator` has encountered a request for [oracle data][Opcode::Oracle].
+    ///
+    /// The caller must resolve these opcodes externally and insert the results into the intermediate witness.
+    /// Once this is done, the `PartialWitnessGenerator` can be restarted to solve the remaining opcodes.
+    RequiresOracleData { required_oracle_data: Vec<OracleData>, unsolved_opcodes: Vec<Opcode> },
+}
+
+#[derive(Debug, PartialEq)]
+pub enum OpcodeResolution {
+    /// The opcode is resolved
+    Solved,
+    /// The opcode is not solvable
+    Stalled(OpcodeNotSolvable),
+    /// The opcode is not solvable but could resolved some witness
+    InProgress,
+}
+
+/// Check if all of the inputs to the function have assignments
+///
+/// Returns the first missing assignment if any are missing
+fn first_missing_assignment(
+    witness_assignments: &BTreeMap<Witness, FieldElement>,
+    inputs: &Vec<FunctionInput>,
+) -> Option<Witness> {
+    inputs.iter().find_map(|input| {
+        if witness_assignments.contains_key(&input.witness) {
+            None
+        } else {
+            Some(input.witness)
+        }
+    })
+}
+
+fn is_stalled(
+    witness_assignments: &BTreeMap<Witness, FieldElement>,
+    inputs: &Vec<FunctionInput>,
+) -> bool {
+    inputs.iter().all(|input| witness_assignments.contains_key(&input.witness))
+}
+
+pub fn solve(
+    backend: impl PartialWitnessGenerator,
+    initial_witness: &mut BTreeMap<Witness, FieldElement>,
+    blocks: &mut Blocks,
+    mut opcode_to_solve: Vec<Opcode>,
+) -> Result<PartialWitnessGeneratorStatus, OpcodeResolutionError> {
+    let mut unresolved_opcodes: Vec<Opcode> = Vec::new();
+    let mut unresolved_oracles: Vec<OracleData> = Vec::new();
+    while !opcode_to_solve.is_empty() || !unresolved_oracles.is_empty() {
+        unresolved_opcodes.clear();
+        let mut stalled = true;
+        let mut opcode_not_solvable = None;
+        for opcode in &opcode_to_solve {
+            let mut solved_oracle_data = None;
+            let resolution = match opcode {
+                Opcode::Arithmetic(expr) => ArithmeticSolver::solve(initial_witness, expr),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall { inputs, .. })
+                    if !is_stalled(initial_witness, inputs) =>
+                {
+                    if let Some(unassigned_witness) =
+                        first_missing_assignment(initial_witness, inputs)
+                    {
+                        Ok(OpcodeResolution::Stalled(OpcodeNotSolvable::MissingAssignment(
+                            unassigned_witness.0,
+                        )))
+                    } else {
+                        // This only exists because Rust won't let us bind in an pattern guard.
+                        // See https://github.com/rust-lang/rust/issues/51114
+                        unreachable!("Only reachable if the blackbox is stalled")
+                    }
+                }
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::AES,
+                    inputs,
+                    outputs,
+                }) => backend.aes(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::AND,
+                    inputs,
+                    outputs,
+                }) => backend.and(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::XOR,
+                    inputs,
+                    outputs,
+                }) => backend.xor(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::RANGE,
+                    inputs,
+                    outputs,
+                }) => backend.range(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::SHA256,
+                    inputs,
+                    outputs,
+                }) => backend.sha256(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::Blake2s,
+                    inputs,
+                    outputs,
+                }) => backend.blake2s(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::ComputeMerkleRoot,
+                    inputs,
+                    outputs,
+                }) => backend.compute_merkle_root(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::SchnorrVerify,
+                    inputs,
+                    outputs,
+                }) => backend.schnorr_verify(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::Pedersen,
+                    inputs,
+                    outputs,
+                }) => backend.pedersen(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::HashToField128Security,
+                    inputs,
+                    outputs,
+                }) => backend.hash_to_field128_security(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::EcdsaSecp256k1,
+                    inputs,
+                    outputs,
+                }) => backend.ecdsa_secp256k1(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::FixedBaseScalarMul,
+                    inputs,
+                    outputs,
+                }) => backend.fixed_base_scalar_mul(initial_witness, inputs, outputs),
+                Opcode::BlackBoxFuncCall(BlackBoxFuncCall {
+                    name: BlackBoxFunc::Keccak256,
+                    inputs,
+                    outputs,
+                }) => backend.keccak256(initial_witness, inputs, outputs),
+                Opcode::Directive(directive) => solve_directives(initial_witness, directive),
+                Opcode::Block(block) | Opcode::ROM(block) | Opcode::RAM(block) => {
+                    blocks.solve(block.id, &block.trace, initial_witness)
+                }
+                Opcode::Oracle(data) => {
+                    let mut data_clone = data.clone();
+                    let result = OracleSolver::solve(initial_witness, &mut data_clone)?;
+                    solved_oracle_data = Some(data_clone);
+                    Ok(result)
+                }
+            };
+            match resolution {
+                Ok(OpcodeResolution::Solved) => {
+                    stalled = false;
+                }
+                Ok(OpcodeResolution::InProgress) => {
+                    stalled = false;
+                    // InProgress Oracles must be externally re-solved
+                    if let Some(oracle) = solved_oracle_data {
+                        unresolved_oracles.push(oracle);
+                    } else {
+                        unresolved_opcodes.push(opcode.clone());
+                    }
+                }
+                Ok(OpcodeResolution::Stalled(not_solvable)) => {
+                    if opcode_not_solvable.is_none() {
+                        // we keep track of the first unsolvable opcode
+                        opcode_not_solvable = Some(not_solvable);
+                    }
+                    // We push those opcodes not solvable to the back as
+                    // it could be because the opcodes are out of order, i.e. this assignment
+                    // relies on a later opcodes' results
+                    unresolved_opcodes.push(match solved_oracle_data {
+                        Some(oracle_data) => Opcode::Oracle(oracle_data),
+                        None => opcode.clone(),
+                    });
+                }
+                Err(OpcodeResolutionError::OpcodeNotSolvable(_)) => {
+                    unreachable!("ICE - Result should have been converted to GateResolution")
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        // We have oracles that must be externally resolved
+        if !unresolved_oracles.is_empty() {
+            return Ok(PartialWitnessGeneratorStatus::RequiresOracleData {
+                required_oracle_data: unresolved_oracles,
+                unsolved_opcodes: unresolved_opcodes,
+            });
+        }
+        // We are stalled because of an opcode being bad
+        if stalled && !unresolved_opcodes.is_empty() {
+            return Err(OpcodeResolutionError::OpcodeNotSolvable(
+                opcode_not_solvable
+                    .expect("infallible: cannot be stalled and None at the same time"),
+            ));
+        }
+        std::mem::swap(&mut opcode_to_solve, &mut unresolved_opcodes);
+    }
+    Ok(PartialWitnessGeneratorStatus::Solved)
+}
 
 // Returns the concrete value for a particular witness
 // If the witness has no assignment, then

--- a/acvm/src/pwg/arithmetic.rs
+++ b/acvm/src/pwg/arithmetic.rs
@@ -4,7 +4,7 @@ use acir::{
 };
 use std::collections::BTreeMap;
 
-use crate::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeNotSolvable, OpcodeResolutionError};
 
 /// An Arithmetic solver will take a Circuit's arithmetic gates with witness assignments
 /// and create the other witness variables

--- a/acvm/src/pwg/blackbox.rs
+++ b/acvm/src/pwg/blackbox.rs
@@ -1,0 +1,94 @@
+use std::collections::BTreeMap;
+
+use acir::{
+    circuit::opcodes::{BlackBoxFuncCall, FunctionInput},
+    native_types::Witness,
+    BlackBoxFunc, FieldElement,
+};
+
+use crate::{OpcodeNotSolvable, OpcodeResolutionError, PartialWitnessGenerator};
+
+use super::OpcodeResolution;
+
+/// Check if all of the inputs to the function have assignments
+///
+/// Returns the first missing assignment if any are missing
+fn first_missing_assignment(
+    witness_assignments: &BTreeMap<Witness, FieldElement>,
+    inputs: &[FunctionInput],
+) -> Option<Witness> {
+    inputs.iter().find_map(|input| {
+        if witness_assignments.contains_key(&input.witness) {
+            None
+        } else {
+            Some(input.witness)
+        }
+    })
+}
+
+/// Check if all of the inputs to the function have assignments
+fn contains_all_inputs(
+    witness_assignments: &BTreeMap<Witness, FieldElement>,
+    inputs: &[FunctionInput],
+) -> bool {
+    inputs.iter().all(|input| witness_assignments.contains_key(&input.witness))
+}
+
+pub(crate) fn solve(
+    backend: &impl PartialWitnessGenerator,
+    initial_witness: &mut BTreeMap<Witness, FieldElement>,
+    bb_func: &BlackBoxFuncCall,
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
+    match bb_func {
+        BlackBoxFuncCall { inputs, .. } if !contains_all_inputs(initial_witness, inputs) => {
+            if let Some(unassigned_witness) = first_missing_assignment(initial_witness, inputs) {
+                Ok(OpcodeResolution::Stalled(OpcodeNotSolvable::MissingAssignment(
+                    unassigned_witness.0,
+                )))
+            } else {
+                // This only exists because Rust won't let us bind in a pattern guard.
+                // See https://github.com/rust-lang/rust/issues/51114
+                unreachable!("Only reachable if the blackbox is stalled")
+            }
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::AES, inputs, outputs } => {
+            backend.aes(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::AND, inputs, outputs } => {
+            backend.and(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::XOR, inputs, outputs } => {
+            backend.xor(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::RANGE, inputs, outputs } => {
+            backend.range(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::SHA256, inputs, outputs } => {
+            backend.sha256(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::Blake2s, inputs, outputs } => {
+            backend.blake2s(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::ComputeMerkleRoot, inputs, outputs } => {
+            backend.compute_merkle_root(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::SchnorrVerify, inputs, outputs } => {
+            backend.schnorr_verify(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::Pedersen, inputs, outputs } => {
+            backend.pedersen(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::HashToField128Security, inputs, outputs } => {
+            backend.hash_to_field128_security(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::EcdsaSecp256k1, inputs, outputs } => {
+            backend.ecdsa_secp256k1(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::FixedBaseScalarMul, inputs, outputs } => {
+            backend.fixed_base_scalar_mul(initial_witness, inputs, outputs)
+        }
+        BlackBoxFuncCall { name: BlackBoxFunc::Keccak256, inputs, outputs } => {
+            backend.keccak256(initial_witness, inputs, outputs)
+        }
+    }
+}

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -6,7 +6,7 @@ use acir::{
     FieldElement,
 };
 
-use crate::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeNotSolvable, OpcodeResolutionError};
 
 use super::{
     arithmetic::{ArithmeticSolver, GateStatus},

--- a/acvm/src/pwg/directives.rs
+++ b/acvm/src/pwg/directives.rs
@@ -8,7 +8,7 @@ use acir::{
 use num_bigint::BigUint;
 use num_traits::Zero;
 
-use crate::{OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeResolutionError};
 
 use super::{get_value, insert_value, sorting::route, witness_to_value};
 

--- a/acvm/src/pwg/hash.rs
+++ b/acvm/src/pwg/hash.rs
@@ -4,7 +4,7 @@ use sha2::Sha256;
 use sha3::Keccak256;
 use std::collections::BTreeMap;
 
-use crate::{OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeResolutionError};
 
 use super::{insert_value, witness_to_value};
 

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -1,5 +1,5 @@
 use super::{insert_value, witness_to_value};
-use crate::{OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeResolutionError};
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
 use std::collections::BTreeMap;
 

--- a/acvm/src/pwg/oracle.rs
+++ b/acvm/src/pwg/oracle.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use acir::{circuit::opcodes::OracleData, native_types::Witness, FieldElement};
 
-use crate::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::OpcodeResolution, OpcodeNotSolvable, OpcodeResolutionError};
 
 use super::{arithmetic::ArithmeticSolver, insert_value};
 

--- a/acvm/src/pwg/range.rs
+++ b/acvm/src/pwg/range.rs
@@ -1,4 +1,4 @@
-use crate::{pwg::witness_to_value, OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::witness_to_value, pwg::OpcodeResolution, OpcodeResolutionError};
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
 use std::collections::BTreeMap;
 

--- a/acvm/src/pwg/signature/ecdsa.rs
+++ b/acvm/src/pwg/signature/ecdsa.rs
@@ -1,7 +1,7 @@
 use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, FieldElement};
 use std::collections::BTreeMap;
 
-use crate::{pwg::witness_to_value, OpcodeResolution, OpcodeResolutionError};
+use crate::{pwg::witness_to_value, pwg::OpcodeResolution, OpcodeResolutionError};
 
 pub fn secp256k1_prehashed(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,


### PR DESCRIPTION
# Related issue(s)

Works towards a resolution of the conversation at https://github.com/noir-lang/acvm/pull/247/files#r1180617953 and puts ACVM in a better position for self-implementing all of the opcodes (one by one).

# Description

## Summary of changes

This removes the `solve` function on the PartialWitnessGenerator trait and moves it into the `pwg` module as a standalone function that takes a backend. It also replaces `solve_black_box_function_call` with individual functions for each black box function being solved. This will allow us to systematically implement the blackbox function calls in ACVM and then remove them from the PWG interface for backends. Until (eventually) they are all gone and the backend doesn't need to implement anything for PWG; instead, just conforming to the ACVM implementation.

I've split these out into separate functions because leaking the BlackBoxFunc enum to a backend is misleading after #247 lands and keccak is handled by ACVM. However, it seems like we'll need pedersen for quite some time (probably as the only one?).

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
