### PR TITLE
chore!: backend can specify which opcode they support

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -208,8 +208,8 @@ pub trait ProofSystemCompiler {
     /// if the language and proof system does not line up.
     fn np_language(&self) -> Language;
 
-    // Returns true if the backend supports the selected black box function
-    fn black_box_function_supported(&self, opcode: &BlackBoxFunc) -> bool;
+    // Returns true if the backend supports the selected opcode
+    fn opcode_supported(&self, opcode: &Opcode) -> bool;
 
     /// Returns the number of gates in a circuit
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> u32;


### PR DESCRIPTION


# Description

## Summary of changes

replace blackbox_supported with opcode_supported

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

This is useful for memory opcodes, we could have a TP backend which supports only ROM opcode for instance.
