### PR TITLE
chore!: expose separate solvers for AND and XOR opcodes

### DIFF
--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -1,58 +1,28 @@
 use super::{insert_value, witness_to_value};
 use crate::{pwg::OpcodeResolution, OpcodeResolutionError};
-use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
+use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, FieldElement};
 use std::collections::BTreeMap;
 
-pub fn solve_logic_opcode(
+/// Solves a [`BlackBoxFunc::And`][acir::circuit::black_box_functions::BlackBoxFunc::AND] opcode and inserts
+/// the result into the supplied witness map
+pub fn and(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    gate: &BlackBoxFuncCall,
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    match func_call.name {
-        BlackBoxFunc::AND => LogicSolver::solve_and_gate(initial_witness, func_call),
-        BlackBoxFunc::XOR => LogicSolver::solve_xor_gate(initial_witness, func_call),
-        _ => Err(OpcodeResolutionError::UnexpectedOpcode("logic opcode", func_call.name)),
-    }
+    let (a, b, result, num_bits) = extract_input_output(gate);
+    solve_logic_gate(initial_witness, &a, &b, result, num_bits, false)
 }
 
-pub struct LogicSolver;
-
-impl LogicSolver {
-    /// Derives the rest of the witness based on the initial low level variables
-    fn solve_logic_gate(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        a: &Witness,
-        b: &Witness,
-        result: Witness,
-        num_bits: u32,
-        is_xor_gate: bool,
-    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-        let w_l_value = witness_to_value(initial_witness, *a)?;
-        let w_r_value = witness_to_value(initial_witness, *b)?;
-
-        let assignment = if is_xor_gate {
-            w_l_value.xor(w_r_value, num_bits)
-        } else {
-            w_l_value.and(w_r_value, num_bits)
-        };
-        insert_value(&result, assignment, initial_witness)?;
-        Ok(OpcodeResolution::Solved)
-    }
-
-    pub fn solve_and_gate(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gate: &BlackBoxFuncCall,
-    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-        let (a, b, result, num_bits) = extract_input_output(gate);
-        LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, false)
-    }
-    pub fn solve_xor_gate(
-        initial_witness: &mut BTreeMap<Witness, FieldElement>,
-        gate: &BlackBoxFuncCall,
-    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-        let (a, b, result, num_bits) = extract_input_output(gate);
-        LogicSolver::solve_logic_gate(initial_witness, &a, &b, result, num_bits, true)
-    }
+/// Solves a [`BlackBoxFunc::XOR`][acir::circuit::black_box_functions::BlackBoxFunc::XOR] opcode and inserts
+/// the result into the supplied witness map
+pub fn xor(
+    initial_witness: &mut BTreeMap<Witness, FieldElement>,
+    gate: &BlackBoxFuncCall,
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
+    let (a, b, result, num_bits) = extract_input_output(gate);
+    solve_logic_gate(initial_witness, &a, &b, result, num_bits, true)
 }
+
 // TODO: Is there somewhere else that we can put this?
 // TODO: extraction methods are needed for some opcodes like logic and range
 pub(crate) fn extract_input_output(
@@ -68,4 +38,25 @@ pub(crate) fn extract_input_output(
     let num_bits = a.num_bits;
 
     (a.witness, b.witness, *result, num_bits)
+}
+
+/// Derives the rest of the witness based on the initial low level variables
+fn solve_logic_gate(
+    initial_witness: &mut BTreeMap<Witness, FieldElement>,
+    a: &Witness,
+    b: &Witness,
+    result: Witness,
+    num_bits: u32,
+    is_xor_gate: bool,
+) -> Result<OpcodeResolution, OpcodeResolutionError> {
+    let w_l_value = witness_to_value(initial_witness, *a)?;
+    let w_r_value = witness_to_value(initial_witness, *b)?;
+
+    let assignment = if is_xor_gate {
+        w_l_value.xor(w_r_value, num_bits)
+    } else {
+        w_l_value.and(w_r_value, num_bits)
+    };
+    insert_value(&result, assignment, initial_witness)?;
+    Ok(OpcodeResolution::Solved)
 }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

The `AND` and `XOR` opcodes are quite strange in so far as they don't have their own solvers, instead we call `solve_logic_opcode` while passing across the opcode which performs a `match` to decide how to handle it. We don't have a `solver_hash_opcode` which handles all of the hash functions so it doesn't really make sense to have one for logic functions.

I've then split up these functions to expose `and()` and `xor()`. Backends will then be expected to a call these directly.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
