### PR TITLE
chore(acir_field): remove unnecessary `to_vec()`

### DIFF
--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -322,7 +322,7 @@ impl<F: PrimeField> FieldElement<F> {
     fn mask_to_be_bytes(&self, num_bits: u32) -> Vec<u8> {
         let mut bytes = self.to_be_bytes();
         mask_vector_le(&mut bytes, num_bits as usize);
-        bytes.to_vec()
+        bytes
     }
 
     fn and_xor(&self, rhs: &FieldElement<F>, num_bits: u32, is_xor: bool) -> FieldElement<F> {


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

Small issue I noticed while working on something else. I imagine the compiler optimises this away anyway but we can remove this call to `to_vec()` as `bytes` is already a `Vec<u8>`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
