### PR TITLE
feat(acvm)!: update black box solver interfaces to match `pwg:black_box::solve`

### DIFF
--- a/acvm/src/compiler/transformers/fallback.rs
+++ b/acvm/src/compiler/transformers/fallback.rs
@@ -76,7 +76,8 @@ impl FallbackTransformer {
     ) -> Result<(u32, Vec<Opcode>), CompileError> {
         let (updated_witness_index, opcodes_fallback) = match gc.name {
             BlackBoxFunc::AND => {
-                let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
+                let (lhs, rhs, result, num_bits) =
+                    crate::pwg::logic::extract_input_output(&gc.inputs, &gc.outputs);
                 stdlib::fallback::and(
                     Expression::from(lhs),
                     Expression::from(rhs),
@@ -86,7 +87,8 @@ impl FallbackTransformer {
                 )
             }
             BlackBoxFunc::XOR => {
-                let (lhs, rhs, result, num_bits) = crate::pwg::logic::extract_input_output(gc);
+                let (lhs, rhs, result, num_bits) =
+                    crate::pwg::logic::extract_input_output(&gc.inputs, &gc.outputs);
                 stdlib::fallback::xor(
                     Expression::from(lhs),
                     Expression::from(rhs),

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -82,7 +82,6 @@ pub trait PartialWitnessGenerator {
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         inputs: &[FunctionInput],
-        outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn sha256(
         &self,

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -282,9 +282,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn and(
             &self,
@@ -292,9 +290,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn xor(
             &self,
@@ -302,18 +298,14 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn range(
             &self,
             _initial_witness: &mut BTreeMap<Witness, FieldElement>,
             _inputs: &[FunctionInput],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn sha256(
             &self,
@@ -321,9 +313,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn blake2s(
             &self,
@@ -331,9 +321,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn compute_merkle_root(
             &self,
@@ -341,9 +329,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn schnorr_verify(
             &self,
@@ -351,9 +337,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn pedersen(
             &self,
@@ -361,9 +345,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn hash_to_field128_security(
             &self,
@@ -371,9 +353,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn ecdsa_secp256k1(
             &self,
@@ -381,9 +361,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn fixed_base_scalar_mul(
             &self,
@@ -391,9 +369,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
         fn keccak256(
             &self,
@@ -401,9 +377,7 @@ mod test {
             _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            {
-                panic!("Path not trodden by this test")
-            }
+            panic!("Path not trodden by this test")
         }
     }
 

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -310,7 +310,6 @@ mod test {
             &self,
             _initial_witness: &mut BTreeMap<Witness, FieldElement>,
             _inputs: &[FunctionInput],
-            _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             {
                 panic!("Path not trodden by this test")

--- a/acvm/src/pwg/blackbox.rs
+++ b/acvm/src/pwg/blackbox.rs
@@ -61,7 +61,8 @@ pub(crate) fn solve(
             backend.xor(initial_witness, inputs, outputs)
         }
         BlackBoxFuncCall { name: BlackBoxFunc::RANGE, inputs, outputs } => {
-            backend.range(initial_witness, inputs, outputs)
+            assert!(outputs.is_empty());
+            backend.range(initial_witness, inputs)
         }
         BlackBoxFuncCall { name: BlackBoxFunc::SHA256, inputs, outputs } => {
             backend.sha256(initial_witness, inputs, outputs)

--- a/acvm/src/pwg/hash.rs
+++ b/acvm/src/pwg/hash.rs
@@ -1,4 +1,4 @@
-use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, FieldElement};
+use acir::{circuit::opcodes::FunctionInput, native_types::Witness, FieldElement};
 use blake2::{Blake2s256, Digest};
 use sha2::Sha256;
 use sha3::Keccak256;
@@ -10,11 +10,12 @@ use super::{insert_value, witness_to_value};
 
 pub fn blake2s256(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
+    outputs: &[Witness],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let hash = generic_hash_256::<Blake2s256>(initial_witness, func_call)?;
+    let hash = generic_hash_256::<Blake2s256>(initial_witness, inputs)?;
 
-    for (output_witness, value) in func_call.outputs.iter().zip(hash.iter()) {
+    for (output_witness, value) in outputs.iter().zip(hash.iter()) {
         insert_value(
             output_witness,
             FieldElement::from_be_bytes_reduce(&[*value]),
@@ -27,11 +28,12 @@ pub fn blake2s256(
 
 pub fn sha256(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
+    outputs: &[Witness],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let hash = generic_hash_256::<Sha256>(initial_witness, func_call)?;
+    let hash = generic_hash_256::<Sha256>(initial_witness, inputs)?;
 
-    for (output_witness, value) in func_call.outputs.iter().zip(hash.iter()) {
+    for (output_witness, value) in outputs.iter().zip(hash.iter()) {
         insert_value(
             output_witness,
             FieldElement::from_be_bytes_reduce(&[*value]),
@@ -44,11 +46,12 @@ pub fn sha256(
 
 pub fn keccak256(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
+    outputs: &[Witness],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let hash = generic_hash_256::<Keccak256>(initial_witness, func_call)?;
+    let hash = generic_hash_256::<Keccak256>(initial_witness, inputs)?;
 
-    for (output_witness, value) in func_call.outputs.iter().zip(hash.iter()) {
+    for (output_witness, value) in outputs.iter().zip(hash.iter()) {
         insert_value(
             output_witness,
             FieldElement::from_be_bytes_reduce(&[*value]),
@@ -61,24 +64,25 @@ pub fn keccak256(
 
 pub fn hash_to_field_128_security(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
+    outputs: &[Witness],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let hash = generic_hash_256::<Blake2s256>(initial_witness, func_call)?;
+    let hash = generic_hash_256::<Blake2s256>(initial_witness, inputs)?;
 
     let reduced_res = FieldElement::from_be_bytes_reduce(&hash);
-    insert_value(&func_call.outputs[0], reduced_res, initial_witness)?;
+    insert_value(&outputs[0], reduced_res, initial_witness)?;
 
     Ok(OpcodeResolution::Solved)
 }
 
 fn generic_hash_256<D: Digest>(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
 ) -> Result<[u8; 32], OpcodeResolutionError> {
     let mut hasher = D::new();
 
     // Read witness assignments into hasher.
-    for input in func_call.inputs.iter() {
+    for input in inputs.iter() {
         let witness = input.witness;
         let num_bits = input.num_bits as usize;
 

--- a/acvm/src/pwg/logic.rs
+++ b/acvm/src/pwg/logic.rs
@@ -31,8 +31,8 @@ pub(crate) fn extract_input_output(
     inputs: &[FunctionInput],
     outputs: &[Witness],
 ) -> (Witness, Witness, Witness, u32) {
-    let a = inputs[0];
-    let b = inputs[1];
+    let a = &inputs[0];
+    let b = &inputs[1];
     let result = outputs[0];
 
     // The num_bits variable should be the same for all witnesses

--- a/acvm/src/pwg/range.rs
+++ b/acvm/src/pwg/range.rs
@@ -1,10 +1,10 @@
 use crate::{pwg::witness_to_value, pwg::OpcodeResolution, OpcodeResolutionError};
-use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, BlackBoxFunc, FieldElement};
+use acir::{circuit::opcodes::FunctionInput, native_types::Witness, BlackBoxFunc, FieldElement};
 use std::collections::BTreeMap;
 
 pub fn solve_range_opcode(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    func_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
     // TODO: this consistency check can be moved to a general function
     let defined_input_size = BlackBoxFunc::RANGE
@@ -13,7 +13,7 @@ pub fn solve_range_opcode(
         .fixed_size()
         .expect("infallible: input for range gate is fixed");
 
-    let num_arguments = func_call.inputs.len();
+    let num_arguments = inputs.len();
     if num_arguments != defined_input_size as usize {
         return Err(OpcodeResolutionError::IncorrectNumFunctionArguments(
             defined_input_size as usize,
@@ -25,7 +25,7 @@ pub fn solve_range_opcode(
     // For the range constraint, we know that the input size should be one
     assert_eq!(defined_input_size, 1);
 
-    let input = func_call.inputs.first().expect("infallible: checked that input size is 1");
+    let input = inputs.first().expect("infallible: checked that input size is 1");
 
     let w_value = witness_to_value(initial_witness, input.witness)?;
     if w_value.num_bits() > input.num_bits {

--- a/acvm/src/pwg/signature/ecdsa.rs
+++ b/acvm/src/pwg/signature/ecdsa.rs
@@ -1,13 +1,14 @@
-use acir::{circuit::opcodes::BlackBoxFuncCall, native_types::Witness, FieldElement};
+use acir::{circuit::opcodes::FunctionInput, native_types::Witness, FieldElement};
 use std::collections::BTreeMap;
 
 use crate::{pwg::witness_to_value, pwg::OpcodeResolution, OpcodeResolutionError};
 
 pub fn secp256k1_prehashed(
     initial_witness: &mut BTreeMap<Witness, FieldElement>,
-    gadget_call: &BlackBoxFuncCall,
+    inputs: &[FunctionInput],
+    outputs: &[Witness],
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-    let mut inputs_iter = gadget_call.inputs.iter();
+    let mut inputs_iter = inputs.iter();
 
     let mut pub_key_x = [0u8; 32];
     for (i, pkx) in pub_key_x.iter_mut().enumerate() {
@@ -50,7 +51,7 @@ pub fn secp256k1_prehashed(
         ecdsa_secp256k1::verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature)
             .is_ok();
 
-    initial_witness.insert(gadget_call.outputs[0], FieldElement::from(result));
+    initial_witness.insert(outputs[0], FieldElement::from(result));
     Ok(OpcodeResolution::Solved)
 }
 


### PR DESCRIPTION
# Related issue(s)

Addresses issue raised in https://github.com/noir-lang/aztec_backend/pull/165

Resolves (link to issue)

# Description

## Summary of changes

This PR updates all the black box solver functions to accept slices of inputs and outputs rather than wanting a `BlackBoxFuncCall`. This prevents us from having to construct them up in aztec_backend just to feed back into ACVM.

As part of this I've updated the `PartialWitnessGenerator` trait to stop passing an `outputs` argument to the range opcode solver as it has no outputs. We could go further and apply similar changes for opcodes with a specified number of inputs/outputs but that felt overkill.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
