### PR TITLE
chore(acvm)!: rename `hash_to_field128_security` to `hash_to_field_128_security`

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -113,7 +113,7 @@ pub trait PartialWitnessGenerator {
         inputs: &[FunctionInput],
         outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn hash_to_field128_security(
+    fn hash_to_field_128_security(
         &self,
         initial_witness: &mut BTreeMap<Witness, FieldElement>,
         inputs: &[FunctionInput],

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -347,7 +347,7 @@ mod test {
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")
         }
-        fn hash_to_field128_security(
+        fn hash_to_field_128_security(
             &self,
             _initial_witness: &mut BTreeMap<Witness, FieldElement>,
             _inputs: &[FunctionInput],

--- a/acvm/src/pwg/blackbox.rs
+++ b/acvm/src/pwg/blackbox.rs
@@ -80,7 +80,7 @@ pub(crate) fn solve(
             backend.pedersen(initial_witness, inputs, outputs)
         }
         BlackBoxFuncCall { name: BlackBoxFunc::HashToField128Security, inputs, outputs } => {
-            backend.hash_to_field128_security(initial_witness, inputs, outputs)
+            backend.hash_to_field_128_security(initial_witness, inputs, outputs)
         }
         BlackBoxFuncCall { name: BlackBoxFunc::EcdsaSecp256k1, inputs, outputs } => {
             backend.ecdsa_secp256k1(initial_witness, inputs, outputs)


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

This name is inconsistent with the name of the matching solver function.

https://github.com/noir-lang/acvm/blob/0098b7d9640076d970e6c15d5fd6f368eb1513ff/acvm/src/pwg/hash.rs#L65

For consistency I've renamed it.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
