### PR TITLE
chore(acvm)!: Backend trait must implement Debug

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -15,6 +15,7 @@ use acir::{
     native_types::{Expression, Witness},
     BlackBoxFunc,
 };
+use core::fmt::Debug;
 use std::collections::BTreeMap;
 use thiserror::Error;
 
@@ -52,7 +53,10 @@ pub enum OpcodeResolutionError {
     BlackBoxFunctionFailed(BlackBoxFunc, String),
 }
 
-pub trait Backend: SmartContract + ProofSystemCompiler + PartialWitnessGenerator + Default {}
+pub trait Backend:
+    SmartContract + ProofSystemCompiler + PartialWitnessGenerator + Default + Debug
+{
+}
 
 /// This component will generate the backend specific output for
 /// each OPCODE.


### PR DESCRIPTION
# Related issue(s)

Resolves #272 (link to issue)

# Description

## Summary of changes

In order to use a Backend trait as a generic in a `thiserror` derived enum, we need the backend to implement Debug. See the linked issue and https://github.com/noir-lang/noir/pull/1322 for further context.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
