### PR TITLE
fix(acir): Hide variants of WitnessMapError and export it from package

### DIFF
--- a/acir/src/native_types/mod.rs
+++ b/acir/src/native_types/mod.rs
@@ -5,3 +5,4 @@ mod witness_map;
 pub use expression::Expression;
 pub use witness::Witness;
 pub use witness_map::WitnessMap;
+pub use witness_map::WitnessMapError;

--- a/cspell.json
+++ b/cspell.json
@@ -34,6 +34,7 @@
         "stdlib",
         "struct",
         "TORADIX",
+        "Msgpack",
         // Dependencies
         //
         "bufread",


### PR DESCRIPTION
# Related issue(s)

Resolves (link to issue)

# Description

## Summary of changes

When trying to update https://github.com/noir-lang/noir/pull/1267, we tried to map the WitnessMapError to a nargo error, but the type isn't exported so it can't be used to derive. This makes it public to consumers, but also hides the enum values so they can't be pattern matched and cause breaking changes if/when updated.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
