### PR TITLE
feat(acvm)!: expose backend identifier on `ProofSystemCompiler` trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -65,13 +65,19 @@ pub trait Backend:
 {
 }
 
+// TODO: improve this name
+pub trait BackendInfo {
+    /// Returns the identifier for the backend.
+    fn identifier(&self) -> String;
+}
+
 // Unfortunately, Rust doesn't natively allow async functions in traits yet.
 // So we need to annotate our trait with this macro and backends need to attach the macro to their `impl`.
 //
 // For more details, see https://docs.rs/async-trait/latest/async_trait/
 // and https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/
 #[async_trait]
-pub trait CommonReferenceString {
+pub trait CommonReferenceString: BackendInfo {
     /// The Error type returned by failed function calls in the CommonReferenceString trait.
     type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate
 
@@ -203,12 +209,9 @@ pub trait SmartContract {
     ) -> Result<String, Self::Error>;
 }
 
-pub trait ProofSystemCompiler {
+pub trait ProofSystemCompiler: BackendInfo {
     /// The Error type returned by failed function calls in the ProofSystemCompiler trait.
     type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate
-
-    /// Returns the identifier for the backend.
-    fn identifier(&self) -> String;
 
     /// The NPC language that this proof system directly accepts.
     /// It is possible for ACVM to transpile to different languages, however it is advised to create a new backend

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -208,7 +208,7 @@ pub trait ProofSystemCompiler {
     type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate
 
     /// Returns the identifier for the backend.
-    fn backend_identifier(&self) -> String;
+    fn identifier(&self) -> String;
 
     /// The NPC language that this proof system directly accepts.
     /// It is possible for ACVM to transpile to different languages, however it is advised to create a new backend

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -207,6 +207,9 @@ pub trait ProofSystemCompiler {
     /// The Error type returned by failed function calls in the ProofSystemCompiler trait.
     type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate
 
+    /// Returns the identifier for the backend.
+    fn backend_identifier(&self) -> String;
+
     /// The NPC language that this proof system directly accepts.
     /// It is possible for ACVM to transpile to different languages, however it is advised to create a new backend
     /// as this in most cases will be inefficient. For this reason, we want to throw a hard error


### PR DESCRIPTION
# Related issue(s)

Resolves #196 

# Description

## Summary of changes

This PR exposes the `backend_identifer` method on `ProofSystemCompiler` which returns a string identifier for the backend.

I'm doing an initial pass through the repos to just include the name of the backend. We can add extra info later on before merging.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
