### PR TITLE
feat(acir): Add length to BlackBoxFuncCall serialization

### DIFF
--- a/acir/src/circuit/opcodes.rs
+++ b/acir/src/circuit/opcodes.rs
@@ -238,7 +238,7 @@ fn serialization_roundtrip() {
 
     let opcode_arith = Opcode::Arithmetic(Expression::default());
 
-    let opcode_black_box_func = Opcode::BlackBoxFuncCall(BlackBoxFuncCall::AES {
+    let aes_black_box_func = Opcode::BlackBoxFuncCall(BlackBoxFuncCall::AES {
         inputs: vec![
             FunctionInput { witness: Witness(1u32), num_bits: 12 },
             FunctionInput { witness: Witness(24u32), num_bits: 32 },
@@ -246,10 +246,24 @@ fn serialization_roundtrip() {
         outputs: vec![Witness(123u32), Witness(245u32)],
     });
 
+    let ecdsa_black_box_func = Opcode::BlackBoxFuncCall(BlackBoxFuncCall::EcdsaSecp256k1 {
+        public_key_x: vec![
+            FunctionInput { witness: Witness(10u32), num_bits: 8 },
+            FunctionInput { witness: Witness(11u32), num_bits: 8 },
+        ],
+        public_key_y: vec![
+            FunctionInput { witness: Witness(12u32), num_bits: 8 },
+            FunctionInput { witness: Witness(13u32), num_bits: 8 },
+        ],
+        signature: vec![FunctionInput { witness: Witness(14u32), num_bits: 8 }],
+        hashed_message: vec![FunctionInput { witness: Witness(15u32), num_bits: 8 }],
+        output: Witness(300u32),
+    });
+
     let opcode_directive =
         Opcode::Directive(Directive::Invert { x: Witness(1234u32), result: Witness(56789u32) });
 
-    let opcodes = vec![opcode_arith, opcode_black_box_func, opcode_directive];
+    let opcodes = vec![opcode_arith, aes_black_box_func, opcode_directive, ecdsa_black_box_func];
 
     for opcode in opcodes {
         let (op, got_op) = read_write(opcode);


### PR DESCRIPTION
# Related issue(s)

Works towards resolving #234. 

# Description

After #269 we moved `BlackBoxFuncCall` to struct variants with explicit function signatures. The inputs are now separated which is a welcome change. However, the way BlackBoxFuncCalls are currently being written still follows the old method when everything was handled in a flattened inputs vector. Now that we are splitting up the inputs into separate input fields this requires us to have hardcoded function signatures when serializing our function inputs. This is fine for our existing blackbox funcs as any current functions that have variable inputs have only one and it can be serialized as the last input of the function signature. 

For recursion we can have multiple function inputs that all vary in size. `VerifyProof` will require a `key`, `proof`, `public_inputs`, `key_hash`, and `input_aggregation_object`. The key hash is a single element that can be computed by the respective backend. Every other function input can vary depending on the proving system. Thus the way we currently read in a flattened vector is not sufficient. 

## Summary of changes

I added a new struct `FunctionInputIO` that stores the length of a given function input. Singular function inputs
are not affected as the function signature determines whether we should fetch the first element of a vector when reading in the function inputs or return a vector with a single element.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

I included one more black box func that has multiple vector based function inputs in the serialization_roundtrip test. 

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
