### PR TITLE
chore!: Remove deprecated circuit hash functions

### DIFF
--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -20,7 +20,6 @@ stdlib.workspace = true
 blake2 = "0.10.6"
 sha2 = "0.10.6"
 sha3 = "0.10.6"
-crc32fast = "1.3.2"
 k256 = { version = "0.7.2", features = [
     "ecdsa",
     "ecdsa-core",

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -257,30 +257,6 @@ pub enum Language {
     PLONKCSat { width: usize },
 }
 
-#[deprecated]
-pub fn hash_constraint_system(cs: &Circuit) -> [u8; 32] {
-    let mut bytes = Vec::new();
-    cs.write(&mut bytes).expect("could not serialize circuit");
-
-    use sha2::{digest::FixedOutput, Digest, Sha256};
-    let mut hasher = Sha256::new();
-
-    hasher.update(bytes);
-    hasher.finalize_fixed().into()
-}
-
-#[deprecated]
-pub fn checksum_constraint_system(cs: &Circuit) -> u32 {
-    let mut bytes = Vec::new();
-    cs.write(&mut bytes).expect("could not serialize circuit");
-
-    use crc32fast::Hasher;
-    let mut hasher = Hasher::new();
-
-    hasher.update(&bytes);
-    hasher.finalize()
-}
-
 #[deprecated(
     note = "For backwards compatibility, this method allows you to derive _sensible_ defaults for opcode support based on the np language. \n Backends should simply specify what they support."
 )]


### PR DESCRIPTION
# Related issue(s)

Followup to https://github.com/noir-lang/acvm/pull/214

# Description

## Summary of changes

These functions were deprecated in the 0.10.0 release and so can be removed in 0.12.0.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
