### PR TITLE
chore!: Remove backend solvable opcodes from PWG trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -67,37 +67,7 @@ pub trait PartialWitnessGenerator {
         inputs: &[FunctionInput],
         outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn and(
-        &self,
-        initial_witness: &mut WitnessMap,
-        lhs: &FunctionInput,
-        rhs: &FunctionInput,
-        output: &Witness,
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn xor(
-        &self,
-        initial_witness: &mut WitnessMap,
-        lhs: &FunctionInput,
-        rhs: &FunctionInput,
-        output: &Witness,
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn range(
-        &self,
-        initial_witness: &mut WitnessMap,
-        input: &FunctionInput,
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn sha256(
-        &self,
-        initial_witness: &mut WitnessMap,
-        inputs: &[FunctionInput],
-        outputs: &[Witness],
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn blake2s(
-        &self,
-        initial_witness: &mut WitnessMap,
-        inputs: &[FunctionInput],
-        outputs: &[Witness],
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
+
     fn compute_merkle_root(
         &self,
         initial_witness: &mut WitnessMap,
@@ -121,31 +91,10 @@ pub trait PartialWitnessGenerator {
         inputs: &[FunctionInput],
         outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn hash_to_field_128_security(
-        &self,
-        initial_witness: &mut WitnessMap,
-        inputs: &[FunctionInput],
-        outputs: &Witness,
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn ecdsa_secp256k1(
-        &self,
-        initial_witness: &mut WitnessMap,
-        public_key_x: &[FunctionInput],
-        public_key_y: &[FunctionInput],
-        signature: &[FunctionInput],
-        message: &[FunctionInput],
-        outputs: &Witness,
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn fixed_base_scalar_mul(
         &self,
         initial_witness: &mut WitnessMap,
         input: &FunctionInput,
-        outputs: &[Witness],
-    ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
-    fn keccak256(
-        &self,
-        initial_witness: &mut WitnessMap,
-        inputs: &[FunctionInput],
         outputs: &[Witness],
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
 }
@@ -291,47 +240,6 @@ mod test {
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")
         }
-        fn and(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _lhs: &FunctionInput,
-            _rhs: &FunctionInput,
-            _output: &Witness,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn xor(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _lhs: &FunctionInput,
-            _rhs: &FunctionInput,
-            _output: &Witness,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn range(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _input: &FunctionInput,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn sha256(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _inputs: &[FunctionInput],
-            _outputs: &[Witness],
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn blake2s(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _inputs: &[FunctionInput],
-            _outputs: &[Witness],
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
         fn compute_merkle_root(
             &self,
             _initial_witness: &mut WitnessMap,
@@ -361,37 +269,10 @@ mod test {
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")
         }
-        fn hash_to_field_128_security(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _inputs: &[FunctionInput],
-            _output: &Witness,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn ecdsa_secp256k1(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _public_key_x: &[FunctionInput],
-            _public_key_y: &[FunctionInput],
-            _signature: &[FunctionInput],
-            _message: &[FunctionInput],
-            _output: &Witness,
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
         fn fixed_base_scalar_mul(
             &self,
             _initial_witness: &mut WitnessMap,
             _input: &FunctionInput,
-            _outputs: &[Witness],
-        ) -> Result<OpcodeResolution, OpcodeResolutionError> {
-            panic!("Path not trodden by this test")
-        }
-        fn keccak256(
-            &self,
-            _initial_witness: &mut WitnessMap,
-            _inputs: &[FunctionInput],
             _outputs: &[Witness],
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")


### PR DESCRIPTION
# Related issue(s)


Continuation of #264 -- Since the bakends are no longer solving particular opcodes, we can remove them from the PWG trait

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
