### PR TITLE
chore: replace all usages of `message` for ECDSA with `hashed_message`

### DIFF
--- a/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -261,16 +261,19 @@ impl BlackBoxFuncCall {
                 public_key_x,
                 public_key_y,
                 signature,
-                hashed_message: message,
+                hashed_message,
                 ..
             } => {
                 let mut inputs = Vec::with_capacity(
-                    public_key_x.len() + public_key_y.len() + signature.len() + message.len(),
+                    public_key_x.len()
+                        + public_key_y.len()
+                        + signature.len()
+                        + hashed_message.len(),
                 );
                 inputs.extend(public_key_x.iter().copied());
                 inputs.extend(public_key_y.iter().copied());
                 inputs.extend(signature.iter().copied());
-                inputs.extend(message.iter().copied());
+                inputs.extend(hashed_message.iter().copied());
                 inputs
             }
         }

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -172,7 +172,7 @@ pub trait PartialWitnessGenerator {
         public_key_x: &[FunctionInput],
         public_key_y: &[FunctionInput],
         signature: &[FunctionInput],
-        message: &[FunctionInput],
+        hashed_message: &[FunctionInput],
         outputs: &Witness,
     ) -> Result<pwg::OpcodeResolution, OpcodeResolutionError>;
     fn fixed_base_scalar_mul(
@@ -398,7 +398,7 @@ mod test {
             _public_key_x: &[FunctionInput],
             _public_key_y: &[FunctionInput],
             _signature: &[FunctionInput],
-            _message: &[FunctionInput],
+            _hashed_message: &[FunctionInput],
             _output: &Witness,
         ) -> Result<OpcodeResolution, OpcodeResolutionError> {
             panic!("Path not trodden by this test")

--- a/acvm/src/pwg/blackbox.rs
+++ b/acvm/src/pwg/blackbox.rs
@@ -87,14 +87,14 @@ pub(crate) fn solve(
             public_key_x,
             public_key_y,
             signature,
-            hashed_message: message,
+            hashed_message,
             output,
         } => backend.ecdsa_secp256k1(
             initial_witness,
             public_key_x,
             public_key_y,
             signature,
-            message,
+            hashed_message,
             output,
         ),
         BlackBoxFuncCall::FixedBaseScalarMul { input, outputs } => {

--- a/acvm/src/pwg/signature/ecdsa.rs
+++ b/acvm/src/pwg/signature/ecdsa.rs
@@ -24,7 +24,7 @@ pub fn secp256k1_prehashed(
     public_key_x_inputs: &[FunctionInput],
     public_key_y_inputs: &[FunctionInput],
     signature_inputs: &[FunctionInput],
-    message_inputs: &[FunctionInput],
+    hashed_message_inputs: &[FunctionInput],
     output: Witness,
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
     let pub_key_x: [u8; 32] =
@@ -51,7 +51,7 @@ pub fn secp256k1_prehashed(
             )
         })?;
 
-    let hashed_message = to_u8_vec(initial_witness, message_inputs)?;
+    let hashed_message = to_u8_vec(initial_witness, hashed_message_inputs)?;
     let result =
         ecdsa_secp256k1::verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature)
             .is_ok();


### PR DESCRIPTION
# Related issue(s)

Motivated by slack messages

# Description

## Summary of changes

This updates all variable/argument names related to ECDSA function to specify that it refers to the hash of the message rather than the message itself.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
