### PR TITLE
fix!: Allow async functions without send on async trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -70,7 +70,7 @@ pub trait Backend:
 //
 // For more details, see https://docs.rs/async-trait/latest/async_trait/
 // and https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/
-#[async_trait]
+#[async_trait(?Send)]
 pub trait CommonReferenceString {
     /// The Error type returned by failed function calls in the CommonReferenceString trait.
     type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate


### PR DESCRIPTION
# Related issue(s)

Resolves (link to issue)

# Description

## Summary of changes

This allows implementors of `#[async_trait]` to not mark their functions as Send. This is needed because the browser fetch API is `async` but not `Send`.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
