### PR TITLE
chore!: Make the elements in Expression/Witness crate visible [DO NOT MERGE]

### DIFF
--- a/acir/src/native_types/expression/mod.rs
+++ b/acir/src/native_types/expression/mod.rs
@@ -19,12 +19,12 @@ pub struct Expression {
     // We collect all of the multiplication terms in the arithmetic gate
     // A multiplication term if of the form q_M * wL * wR
     // Hence this vector represents the following sum: q_M1 * wL1 * wR1 + q_M2 * wL2 * wR2 + .. +
-    pub mul_terms: Vec<(FieldElement, Witness, Witness)>,
+    pub(crate) mul_terms: Vec<(FieldElement, Witness, Witness)>,
 
-    pub linear_combinations: Vec<(FieldElement, Witness)>,
+    pub(crate) linear_combinations: Vec<(FieldElement, Witness)>,
     // TODO: rename q_c to `constant` moreover q_X is not clear to those who
     // TODO are not familiar with PLONK
-    pub q_c: FieldElement,
+    pub(crate) q_c: FieldElement,
 }
 
 impl Default for Expression {

--- a/acir/src/native_types/witness.rs
+++ b/acir/src/native_types/witness.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(
     Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize,
 )]
-pub struct Witness(pub u32);
+pub struct Witness(pub(crate) u32);
 
 impl Witness {
     pub fn new(witness_index: u32) -> Witness {


### PR DESCRIPTION

# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves (link to issue)

# Description

We currently make the fields in Expression/Witness public while having methods which allow us to insert these elements.

I have made the fields crate visible which means that changes to them will no longer be breaking, since dependants won't be able to access it.

TODO: We need to expose getter methods for the inner fields. The current usecase for this is when serializing, for example in acvm-backend-barretenberg, we only need it to convert ACIR to cpp structure, but if the cpp code could serialize the whole ACIR, then we may need this.

I'm going to leave this on hold until that situation is concluded. 

## Summary of changes

(Describe the changes in this PR. Point out breaking changes if any.)

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
