### PR TITLE
chore: make `Value` and `RegisterIndex` fields private

### DIFF
--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -443,16 +443,16 @@ mod test {
 
         let equal_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         let less_than_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(3),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(3),
         };
 
         let brillig_data = Brillig {
@@ -478,8 +478,8 @@ mod test {
                 // Oracles are named 'foreign calls' in brillig
                 brillig_bytecode::Opcode::ForeignCall {
                     function: "invert".into(),
-                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex(1)),
-                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex(0)),
+                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(1)),
+                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(0)),
                 },
             ],
             predicate: None,
@@ -528,7 +528,7 @@ mod test {
         assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
         // Alter Brillig oracle opcode
         brillig.foreign_call_results.push(ForeignCallResult {
-            values: vec![Value::from(foreign_call_wait_info.inputs[0].inner.inverse())],
+            values: vec![Value::from(foreign_call_wait_info.inputs[0].to_field().inverse())],
         });
         let mut next_opcodes_for_solving = vec![Opcode::Brillig(brillig)];
         next_opcodes_for_solving.extend_from_slice(&unsolved_opcodes[..]);
@@ -564,16 +564,16 @@ mod test {
 
         let equal_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(4),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(4),
         };
 
         let less_than_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(5),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(5),
         };
 
         let brillig_data = Brillig {
@@ -606,13 +606,13 @@ mod test {
                 // Oracles are named 'foreign calls' in brillig
                 brillig_bytecode::Opcode::ForeignCall {
                     function: "invert".into(),
-                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex(1)),
-                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex(0)),
+                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(1)),
+                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(0)),
                 },
                 brillig_bytecode::Opcode::ForeignCall {
                     function: "invert".into(),
-                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex(3)),
-                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex(2)),
+                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(3)),
+                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(2)),
                 },
             ],
             predicate: None,
@@ -662,7 +662,7 @@ mod test {
             unresolved_brilligs.remove(0);
         assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 
-        let x_plus_y_inverse = foreign_call_wait_info.inputs[0].inner.inverse();
+        let x_plus_y_inverse = foreign_call_wait_info.inputs[0].to_field().inverse();
         // Alter Brillig oracle opcode
         brillig
             .foreign_call_results
@@ -685,7 +685,7 @@ mod test {
             unresolved_brilligs.remove(0);
         assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
 
-        let i_plus_j_inverse = foreign_call_wait_info.inputs[0].inner.inverse();
+        let i_plus_j_inverse = foreign_call_wait_info.inputs[0].to_field().inverse();
         assert_ne!(x_plus_y_inverse, i_plus_j_inverse);
         // Alter Brillig oracle opcode
         brillig
@@ -724,16 +724,16 @@ mod test {
 
         let equal_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         let less_than_opcode = brillig_bytecode::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(3),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(3),
         };
 
         let brillig_opcode = Opcode::Brillig(Brillig {
@@ -757,8 +757,8 @@ mod test {
                 // Oracles are named 'foreign calls' in brillig
                 brillig_bytecode::Opcode::ForeignCall {
                     function: "invert".into(),
-                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex(1)),
-                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex(0)),
+                    destination: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(1)),
+                    input: RegisterValueOrArray::RegisterIndex(RegisterIndex::from(0)),
                 },
             ],
             predicate: Some(Expression::default()),

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -116,16 +116,16 @@ impl BrilligSolver {
         let result = match vm_status {
             VMStatus::Finished => {
                 for (i, output) in brillig.outputs.iter().enumerate() {
-                    let register_value = vm.get_registers().get(RegisterIndex(i));
+                    let register_value = vm.get_registers().get(RegisterIndex::from(i));
                     match output {
                         BrilligOutputs::Simple(witness) => {
-                            insert_value(witness, register_value.inner, initial_witness)?;
+                            insert_value(witness, register_value.to_field(), initial_witness)?;
                         }
                         BrilligOutputs::Array(witness_arr) => {
                             // Treat the register value as a pointer to memory
                             for (i, witness) in witness_arr.iter().enumerate() {
                                 let value = &vm.get_memory()[register_value.to_usize() + i];
-                                insert_value(witness, value.inner, initial_witness)?;
+                                insert_value(witness, value.to_field(), initial_witness)?;
                             }
                         }
                     }

--- a/brillig_bytecode/src/lib.rs
+++ b/brillig_bytecode/src/lib.rs
@@ -257,7 +257,7 @@ impl VM {
         let lhs_value = self.registers.get(lhs);
         let rhs_value = self.registers.get(rhs);
 
-        let result_value = op.evaluate_field(lhs_value.inner, rhs_value.inner);
+        let result_value = op.evaluate_field(lhs_value.to_field(), rhs_value.to_field());
 
         self.registers.set(result, result_value.into())
     }
@@ -305,9 +305,9 @@ mod tests {
         let opcode = Opcode::BinaryIntOp {
             op: BinaryIntOp::Add,
             bit_size: 2,
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         // Start VM
@@ -323,7 +323,7 @@ mod tests {
         // The register at index `2` should have the value of 3 since we had an
         // add opcode
         let VM { registers, .. } = vm;
-        let output_value = registers.get(RegisterIndex(2));
+        let output_value = registers.get(RegisterIndex::from(2));
 
         assert_eq!(output_value, Value::from(3u128))
     }
@@ -335,17 +335,17 @@ mod tests {
 
         let lhs = {
             registers.push(Value::from(2u128));
-            RegisterIndex(registers.len() - 1)
+            RegisterIndex::from(registers.len() - 1)
         };
 
         let rhs = {
             registers.push(Value::from(2u128));
-            RegisterIndex(registers.len() - 1)
+            RegisterIndex::from(registers.len() - 1)
         };
 
         let destination = {
             registers.push(Value::from(0u128));
-            RegisterIndex(registers.len() - 1)
+            RegisterIndex::from(registers.len() - 1)
         };
 
         let equal_cmp_opcode = Opcode::BinaryIntOp {
@@ -357,14 +357,14 @@ mod tests {
         };
         opcodes.push(equal_cmp_opcode);
         opcodes.push(Opcode::Jump { location: 2 });
-        opcodes.push(Opcode::JumpIf { condition: RegisterIndex(2), location: 3 });
+        opcodes.push(Opcode::JumpIf { condition: RegisterIndex::from(2), location: 3 });
 
         let mut vm = VM::new(Registers { inner: registers }, vec![], opcodes, vec![]);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
 
-        let output_cmp_value = vm.registers.get(RegisterIndex(2));
+        let output_cmp_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(output_cmp_value, Value::from(true));
 
         let status = vm.process_opcode();
@@ -383,20 +383,21 @@ mod tests {
 
         let not_equal_cmp_opcode = Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         let jump_opcode = Opcode::Jump { location: 2 };
 
-        let jump_if_not_opcode = Opcode::JumpIfNot { condition: RegisterIndex(2), location: 1 };
+        let jump_if_not_opcode =
+            Opcode::JumpIfNot { condition: RegisterIndex::from(2), location: 1 };
 
         let add_opcode = Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Add,
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         let mut vm = VM::new(
@@ -412,7 +413,7 @@ mod tests {
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
 
-        let output_cmp_value = vm.registers.get(RegisterIndex(2));
+        let output_cmp_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(output_cmp_value, Value::from(false));
 
         let status = vm.process_opcode();
@@ -423,7 +424,7 @@ mod tests {
 
         // The register at index `2` should have not changed as we jumped over the add opcode
         let VM { registers, .. } = vm;
-        let output_value = registers.get(RegisterIndex(2));
+        let output_value = registers.get(RegisterIndex::from(2));
         assert_eq!(output_value, Value::from(false));
     }
 
@@ -432,7 +433,8 @@ mod tests {
         let input_registers =
             Registers::load(vec![Value::from(1u128), Value::from(2u128), Value::from(3u128)]);
 
-        let mov_opcode = Opcode::Mov { destination: RegisterIndex(2), source: RegisterIndex(0) };
+        let mov_opcode =
+            Opcode::Mov { destination: RegisterIndex::from(2), source: RegisterIndex::from(0) };
 
         let mut vm = VM::new(input_registers, vec![], vec![mov_opcode], vec![]);
 
@@ -441,10 +443,10 @@ mod tests {
 
         let VM { registers, .. } = vm;
 
-        let destination_value = registers.get(RegisterIndex(2));
+        let destination_value = registers.get(RegisterIndex::from(2));
         assert_eq!(destination_value, Value::from(1u128));
 
-        let source_value = registers.get(RegisterIndex(0));
+        let source_value = registers.get(RegisterIndex::from(0));
         assert_eq!(source_value, Value::from(1u128));
     }
 
@@ -461,33 +463,33 @@ mod tests {
         let equal_opcode = Opcode::BinaryIntOp {
             bit_size: 1,
             op: BinaryIntOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(1),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(1),
+            destination: RegisterIndex::from(2),
         };
 
         let not_equal_opcode = Opcode::BinaryIntOp {
             bit_size: 1,
             op: BinaryIntOp::Cmp(Comparison::Eq),
-            lhs: RegisterIndex(0),
-            rhs: RegisterIndex(3),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(0),
+            rhs: RegisterIndex::from(3),
+            destination: RegisterIndex::from(2),
         };
 
         let less_than_opcode = Opcode::BinaryIntOp {
             bit_size: 1,
             op: BinaryIntOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex(3),
-            rhs: RegisterIndex(4),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(3),
+            rhs: RegisterIndex::from(4),
+            destination: RegisterIndex::from(2),
         };
 
         let less_than_equal_opcode = Opcode::BinaryIntOp {
             bit_size: 1,
             op: BinaryIntOp::Cmp(Comparison::Lte),
-            lhs: RegisterIndex(3),
-            rhs: RegisterIndex(4),
-            destination: RegisterIndex(2),
+            lhs: RegisterIndex::from(3),
+            rhs: RegisterIndex::from(4),
+            destination: RegisterIndex::from(2),
         };
 
         let mut vm = VM::new(
@@ -500,25 +502,25 @@ mod tests {
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
 
-        let output_eq_value = vm.registers.get(RegisterIndex(2));
+        let output_eq_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(output_eq_value, Value::from(true));
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
 
-        let output_neq_value = vm.registers.get(RegisterIndex(2));
+        let output_neq_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(output_neq_value, Value::from(false));
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
 
-        let lt_value = vm.registers.get(RegisterIndex(2));
+        let lt_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(lt_value, Value::from(true));
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::Finished);
 
-        let lte_value = vm.registers.get(RegisterIndex(2));
+        let lte_value = vm.registers.get(RegisterIndex::from(2));
         assert_eq!(lte_value, Value::from(true));
     }
     #[test]
@@ -531,9 +533,9 @@ mod tests {
         ///         i += 1;
         ///     }
         fn brillig_write_memory(memory: Vec<Value>) -> Vec<Value> {
-            let r_i = RegisterIndex(0);
-            let r_len = RegisterIndex(1);
-            let r_tmp = RegisterIndex(2);
+            let r_i = RegisterIndex::from(0);
+            let r_len = RegisterIndex::from(1);
+            let r_tmp = RegisterIndex::from(2);
             let start = [
                 // i = 0
                 Opcode::Const { destination: r_i, value: 0u128.into() },
@@ -594,10 +596,10 @@ mod tests {
         ///         i += 1;
         ///     }
         fn brillig_sum_memory(memory: Vec<Value>) -> Value {
-            let r_i = RegisterIndex(0);
-            let r_len = RegisterIndex(1);
-            let r_sum = RegisterIndex(2);
-            let r_tmp = RegisterIndex(3);
+            let r_i = RegisterIndex::from(0);
+            let r_len = RegisterIndex::from(1);
+            let r_sum = RegisterIndex::from(2);
+            let r_tmp = RegisterIndex::from(3);
             let start = [
                 // sum = 0
                 Opcode::Const { destination: r_sum, value: 0u128.into() },
@@ -667,9 +669,9 @@ mod tests {
         ///     }
         /// Note we represent a 100% in-register optimized form in brillig
         fn brillig_recursive_write_memory(memory: Vec<Value>) -> Vec<Value> {
-            let r_i = RegisterIndex(0);
-            let r_len = RegisterIndex(1);
-            let r_tmp = RegisterIndex(2);
+            let r_i = RegisterIndex::from(0);
+            let r_len = RegisterIndex::from(1);
+            let r_tmp = RegisterIndex::from(2);
 
             let start = [
                 // i = 0
@@ -757,8 +759,8 @@ mod tests {
 
     #[test]
     fn foreign_call_opcode_register_result() {
-        let r_input = RegisterIndex(0);
-        let r_result = RegisterIndex(1);
+        let r_input = RegisterIndex::from(0);
+        let r_result = RegisterIndex::from(1);
 
         let double_program = vec![
             // Load input register with value 5
@@ -802,8 +804,8 @@ mod tests {
     }
     #[test]
     fn foreign_call_opcode_memory_result() {
-        let r_input = RegisterIndex(0);
-        let r_output = RegisterIndex(1);
+        let r_input = RegisterIndex::from(0);
+        let r_output = RegisterIndex::from(1);
 
         // Define a simple 2x2 matrix in memory
         let initial_matrix =

--- a/brillig_bytecode/src/registers.rs
+++ b/brillig_bytecode/src/registers.rs
@@ -1,5 +1,4 @@
 use crate::Value;
-use acir_field::FieldElement;
 use serde::{Deserialize, Serialize};
 
 /// Registers will store field element values during the
@@ -34,13 +33,19 @@ impl Iterator for RegistersIntoIterator {
         Some(self.registers.inner[self.index - 1])
     }
 }
-/// RegisterIndex refers to the index of a register in the VM.
+/// `RegisterIndex` refers to the index of a register in the VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct RegisterIndex(pub usize);
+pub struct RegisterIndex(usize);
 
 impl RegisterIndex {
-    pub fn inner(self) -> usize {
+    pub fn to_usize(self) -> usize {
         self.0
+    }
+}
+
+impl From<usize> for RegisterIndex {
+    fn from(value: usize) -> Self {
+        RegisterIndex(value)
     }
 }
 
@@ -52,16 +57,16 @@ impl Registers {
 
     /// Gets the values at register with address `index`
     pub fn get(&self, register: RegisterIndex) -> Value {
-        self.inner[register.inner()]
+        self.inner[register.to_usize()]
     }
 
     /// Sets the value at register with address `index` to `value`
     pub fn set(&mut self, index: RegisterIndex, value: Value) {
-        if index.inner() >= self.inner.len() {
-            let diff = index.inner() - self.inner.len() + 1;
-            self.inner.extend(vec![Value { inner: FieldElement::from(0u128) }; diff])
+        if index.to_usize() >= self.inner.len() {
+            let diff = index.to_usize() - self.inner.len() + 1;
+            self.inner.extend(vec![Value::from(0u128); diff])
         }
-        self.inner[index.inner()] = value
+        self.inner[index.to_usize()] = value
     }
 
     /// Returns all of the values in the register

--- a/brillig_bytecode/src/value.rs
+++ b/brillig_bytecode/src/value.rs
@@ -30,7 +30,7 @@ impl Value {
     /// Converts `Value` into a `u128`.
     // TODO: Check what happens if `Value` cannot fit into a u128
     pub fn to_u128(&self) -> u128 {
-        self.inner.to_u128()
+        self.to_field().to_u128()
     }
 
     /// Converts `Value` into a u64 and then casts it into a usize.

--- a/brillig_bytecode/src/value.rs
+++ b/brillig_bytecode/src/value.rs
@@ -13,7 +13,7 @@ pub enum Typ {
 /// Value represents the base descriptor for a value in the VM.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Value {
-    pub inner: FieldElement,
+    inner: FieldElement,
 }
 
 impl Value {
@@ -22,7 +22,12 @@ impl Value {
         self.inner.is_zero()
     }
 
-    /// Converts `Value` into a u128.
+    /// Converts `Value` into a `FieldElement`.
+    pub fn to_field(&self) -> FieldElement {
+        self.inner
+    }
+
+    /// Converts `Value` into a `u128`.
     // TODO: Check what happens if `Value` cannot fit into a u128
     pub fn to_u128(&self) -> u128 {
         self.inner.to_u128()
@@ -57,11 +62,7 @@ impl From<FieldElement> for Value {
 
 impl From<bool> for Value {
     fn from(value: bool) -> Self {
-        if value {
-            Value { inner: FieldElement::one() }
-        } else {
-            Value { inner: FieldElement::zero() }
-        }
+        Value { inner: FieldElement::from(value) }
     }
 }
 


### PR DESCRIPTION
# Related issue(s)

Resolves https://github.com/noir-lang/acvm/pull/152#discussion_r1201547932
Resolves https://github.com/noir-lang/acvm/pull/152#discussion_r1201547233

# Description

## Summary of changes

This PR makes the internal fields of `Value` and `RegisterIndex` private and exposes relevant getters / implements `From` to maintain functionality.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
