### PR TITLE
chore: Resolve TODO when handling inputs in the BrilligSolver to use get_value

### DIFF
--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -5,10 +5,7 @@ use acir::{
     FieldElement,
 };
 
-use crate::{
-    pwg::OpcodeNotSolvable,
-    OpcodeResolution, OpcodeResolutionError,
-};
+use crate::{pwg::OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
 
 use super::{get_value, insert_value};
 

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -6,7 +6,7 @@ use acir::{
 };
 
 use crate::{
-    pwg::{arithmetic::ArithmeticSolver, OpcodeNotSolvable},
+    pwg::OpcodeNotSolvable,
     OpcodeResolution, OpcodeResolutionError,
 };
 

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -53,7 +53,7 @@ impl BrilligSolver {
         // Each input represents an expression or array of expressions to evaluate.
         // Iterate over each input and evaluate the expression(s) associated with it.
         // Push the results into registers and/or memory.
-        // If a certain expression was not solvable, we stall the Brillig VM execution.
+        // If a certain expression is not solvable, we stall the Brillig VM execution.
         for input in &brillig.inputs {
             match input {
                 BrilligInputs::Single(expr) => match get_value(expr, initial_witness) {


### PR DESCRIPTION
# Related issue(s)

Resolves #303

# Description

This moves to get_value rather than calling `ArithmeticSolver::evaluate` directly in BrilligSolver. 

## Summary of changes

This move also lets us simplify the logic for determining whether the PWG needs to stall. Previously we were comparing the size of the inputs declared in the Brillig call to the input registers that were actually resolved against the witness. We can now get rid of this check as return with `OpcodeResolution::Stalled` directly inside the loop that is resolving the brillig inputs. Returning earlier also let us remove the `continue_eval` flag that told us to escape the brillig inputs resolution loop as to not add an unresolved array ID to the brillig input registers 

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [X] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [X] I have reviewed the changes on GitHub, line by line.
- [X] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
