### PR TITLE
chore: Brillig BinaryFieldOp simplification, rename resolve_foreign_call_input

### DIFF
--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -84,7 +84,7 @@ impl BlackBoxFunc {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use strum::IntoEnumIterator;
 
     use crate::BlackBoxFunc;

--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -108,7 +108,7 @@ impl PublicInputs {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::BTreeSet;
 
     use super::{

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -406,7 +406,7 @@ impl<F: PrimeField> SubAssign for FieldElement<F> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     #[test]
     fn and() {
         let max = 10_000u32;

--- a/acvm/src/compiler/optimizers/simplify.rs
+++ b/acvm/src/compiler/optimizers/simplify.rs
@@ -430,7 +430,7 @@ impl CircuitSimplifier {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use acir::{
         circuit::{Circuit, Opcode},
         native_types::{Expression, Witness},

--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -441,7 +441,6 @@ mod tests {
         let w_z_inverse = Witness(5);
         let w_x_plus_y = Witness(6);
         let w_equal_res = Witness(7);
-        let w_lt_res = Witness(8);
 
         let equal_opcode = brillig_vm::Opcode::BinaryFieldOp {
             op: BinaryFieldOp::Equals,

--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -290,13 +290,12 @@ pub fn default_is_opcode_supported(language: Language) -> fn(&Opcode) -> bool {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use std::collections::BTreeMap;
 
     use acir::{
         brillig_vm::{
-            self, BinaryFieldOp, Comparison, ForeignCallResult, RegisterIndex,
-            RegisterValueOrArray, Value,
+            self, BinaryFieldOp, ForeignCallResult, RegisterIndex, RegisterValueOrArray, Value,
         },
         circuit::{
             brillig::{Brillig, BrilligInputs, BrilligOutputs},
@@ -431,7 +430,7 @@ mod test {
         //     let z = x + y;
         //     assert( 1/z == Oracle("inverse", x + y) );
         // }
-        // Also performs an unrelated equality check and less-than check
+        // Also performs an unrelated equality check
         // just for the sake of testing multiple brillig opcodes.
         let fe_0 = FieldElement::zero();
         let fe_1 = FieldElement::one();
@@ -445,17 +444,10 @@ mod test {
         let w_lt_res = Witness(8);
 
         let equal_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Eq),
+            op: BinaryFieldOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(1),
             destination: RegisterIndex::from(2),
-        };
-
-        let less_than_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex::from(0),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(3),
         };
 
         let brillig_data = Brillig {
@@ -473,13 +465,11 @@ mod test {
                 BrilligOutputs::Simple(w_x_plus_y), // Output Register 0 - from input
                 BrilligOutputs::Simple(w_oracle),   // Output Register 1
                 BrilligOutputs::Simple(w_equal_res), // Output Register 2
-                BrilligOutputs::Simple(w_lt_res),   // Output Register 3
             ],
             // stack of foreign call/oracle resolutions, starts empty
             foreign_call_results: vec![],
             bytecode: vec![
                 equal_opcode,
-                less_than_opcode,
                 // Oracles are named 'foreign calls' in brillig
                 brillig_vm::Opcode::ForeignCall {
                     function: "invert".into(),
@@ -554,7 +544,7 @@ mod test {
         //     assert( 1/z == Oracle("inverse", x + y) );
         //     assert( 1/ij == Oracle("inverse", i + j) );
         // }
-        // Also performs an unrelated equality check and less-than check
+        // Also performs an unrelated equality check
         // just for the sake of testing multiple brillig opcodes.
         let fe_0 = FieldElement::zero();
         let fe_1 = FieldElement::one();
@@ -565,25 +555,16 @@ mod test {
         let w_z_inverse = Witness(5);
         let w_x_plus_y = Witness(6);
         let w_equal_res = Witness(7);
-        let w_lt_res = Witness(8);
-
-        let w_i = Witness(9);
-        let w_j = Witness(10);
-        let w_ij_oracle = Witness(11);
-        let w_i_plus_j = Witness(12);
+        let w_i = Witness(8);
+        let w_j = Witness(9);
+        let w_ij_oracle = Witness(10);
+        let w_i_plus_j = Witness(11);
 
         let equal_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Eq),
+            op: BinaryFieldOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(1),
             destination: RegisterIndex::from(4),
-        };
-
-        let less_than_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex::from(0),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(5),
         };
 
         let brillig_data = Brillig {
@@ -608,13 +589,11 @@ mod test {
                 BrilligOutputs::Simple(w_i_plus_j), // Output Register 2 - from input
                 BrilligOutputs::Simple(w_ij_oracle), // Output Register 3
                 BrilligOutputs::Simple(w_equal_res), // Output Register 4
-                BrilligOutputs::Simple(w_lt_res),   // Output Register 5
             ],
             // stack of foreign call/oracle resolutions, starts empty
             foreign_call_results: vec![],
             bytecode: vec![
                 equal_opcode,
-                less_than_opcode,
                 // Oracles are named 'foreign calls' in brillig
                 brillig_vm::Opcode::ForeignCall {
                     function: "invert".into(),
@@ -655,8 +634,8 @@ mod test {
         let mut witness_assignments = BTreeMap::from([
             (Witness(1), FieldElement::from(2u128)),
             (Witness(2), FieldElement::from(3u128)),
-            (Witness(9), FieldElement::from(5u128)),
-            (Witness(10), FieldElement::from(10u128)),
+            (Witness(8), FieldElement::from(5u128)),
+            (Witness(9), FieldElement::from(10u128)),
         ])
         .into();
         let mut blocks = Blocks::default();
@@ -735,17 +714,10 @@ mod test {
         let w_lt_res = Witness(8);
 
         let equal_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Eq),
+            op: BinaryFieldOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(1),
             destination: RegisterIndex::from(2),
-        };
-
-        let less_than_opcode = brillig_vm::Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Lt),
-            lhs: RegisterIndex::from(0),
-            rhs: RegisterIndex::from(1),
-            destination: RegisterIndex::from(3),
         };
 
         let brillig_opcode = Opcode::Brillig(Brillig {
@@ -765,7 +737,6 @@ mod test {
             ],
             bytecode: vec![
                 equal_opcode,
-                less_than_opcode,
                 // Oracles are named 'foreign calls' in brillig
                 brillig_vm::Opcode::ForeignCall {
                     function: "invert".into(),

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -121,7 +121,7 @@ impl BlockSolver {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use acir::{
         circuit::opcodes::{BlockId, MemOp},
         native_types::{Expression, Witness, WitnessMap},

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -86,7 +86,7 @@ impl BrilligSolver {
 
         // Instantiate a Brillig VM given the solved input registers and memory
         // along with the Brillig bytecode, and any present foreign call results.
-        let input_registers = Registers { inner: input_register_values };
+        let input_registers = Registers::load(input_register_values);
         let mut vm = VM::new(
             input_registers,
             input_memory,

--- a/acvm/src/pwg/sorting.rs
+++ b/acvm/src/pwg/sorting.rs
@@ -244,7 +244,7 @@ pub fn route(inputs: Vec<FieldElement>, outputs: Vec<FieldElement>) -> Vec<bool>
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use crate::pwg::sorting::route;
     use acir::FieldElement;
     use rand::prelude::*;

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -43,23 +43,25 @@ pub struct ForeignCallResult {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-// VM encapsulates the state of the Brillig VM during execution.
+/// VM encapsulates the state of the Brillig VM during execution.
 pub struct VM {
-    // Register storage
+    /// Register storage
     registers: Registers,
-    // Instruction pointer
+    /// Instruction pointer
     program_counter: usize,
-    // Tracks foreign calls
+    /// A counter maintained throughout a Brillig process that determines
+    /// whether the caller has resolved the results of a [foreign call][Opcode::ForeignCall].
     foreign_call_counter: usize,
-    // Holds foreign call results
+    /// Represents the outputs of all foreign calls during a Brillig process
+    /// List is appended onto by the caller upon reaching a [VMStatus::ForeignCallWait]
     foreign_call_results: Vec<ForeignCallResult>,
-    // Executable opcodes
+    /// Executable opcodes
     bytecode: Vec<Opcode>,
-    // Status of the VM
+    /// Status of the VM
     status: VMStatus,
-    // Memory of the VM
+    /// Memory of the VM
     memory: Vec<Value>,
-    // Call stack
+    /// Call stack
     call_stack: Vec<Value>,
 }
 

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -10,8 +10,8 @@ mod opcodes;
 mod registers;
 mod value;
 
+pub use opcodes::Opcode;
 pub use opcodes::{BinaryFieldOp, BinaryIntOp, RegisterValueOrArray};
-pub use opcodes::{Comparison, Opcode};
 pub use registers::{RegisterIndex, Registers};
 use serde::{Deserialize, Serialize};
 pub use value::Typ;
@@ -43,22 +43,28 @@ pub struct ForeignCallResult {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
+// VM encapsulates the state of the Brillig VM during execution.
 pub struct VM {
+    // Register storage
     registers: Registers,
+    // Instruction pointer
     program_counter: usize,
-    /// A counter maintained throughout a Brillig process that determines
-    /// whether the caller has resolved the results of a [foreign call][Opcode::ForeignCall].
+    // Tracks foreign calls
     foreign_call_counter: usize,
-    /// Represents the outputs of all foreign calls during a Brillig process
-    /// List is appended onto by the caller upon reaching a [VMStatus::ForeignCallWait]
+    // Holds foreign call results
     foreign_call_results: Vec<ForeignCallResult>,
+    // Executable opcodes
     bytecode: Vec<Opcode>,
+    // Status of the VM
     status: VMStatus,
+    // Memory of the VM
     memory: Vec<Value>,
+    // Call stack
     call_stack: Vec<Value>,
 }
 
 impl VM {
+    /// Constructs a new VM instance
     pub fn new(
         inputs: Registers,
         memory: Vec<Value>,
@@ -77,14 +83,14 @@ impl VM {
         }
     }
 
-    /// Returns the current status of the VM.
+    /// Updates the current status of the VM.
+    /// Returns the given status.
     fn status(&mut self, status: VMStatus) -> VMStatus {
         self.status = status.clone();
         status
     }
 
-    /// Sets the current status of the VM to `finished`.
-    /// Indicating that the VM has completed execution.
+    /// Sets the current status of the VM to Finished (completed execution).
     fn finish(&mut self) -> VMStatus {
         self.status(VMStatus::Finished)
     }
@@ -168,7 +174,7 @@ impl VM {
                     // resolved inputs back to the caller. Once the caller pushes to `foreign_call_results`,
                     // they can then make another call to the VM that starts at this opcode
                     // but has the necessary results to proceed with execution.
-                    let resolved_inputs = self.resolve_foreign_call_input(*input);
+                    let resolved_inputs = self.get_register_value_or_memory_values(*input);
                     return self.wait_for_foreign_call(function.clone(), resolved_inputs);
                 }
 
@@ -254,7 +260,7 @@ impl VM {
         self.status.clone()
     }
 
-    fn resolve_foreign_call_input(&self, input: RegisterValueOrArray) -> Vec<Value> {
+    fn get_register_value_or_memory_values(&self, input: RegisterValueOrArray) -> Vec<Value> {
         match input {
             RegisterValueOrArray::RegisterIndex(index) => vec![self.registers.get(index)],
             RegisterValueOrArray::HeapArray(index, size) => {
@@ -298,14 +304,6 @@ impl VM {
 
         self.registers.set(result, result_value.into());
     }
-}
-
-pub struct VMOutputState {
-    pub registers: Registers,
-    pub program_counter: usize,
-    pub foreign_call_results: Vec<ForeignCallResult>,
-    pub status: VMStatus,
-    pub memory: Vec<Value>,
 }
 
 #[cfg(test)]
@@ -367,18 +365,13 @@ mod tests {
             RegisterIndex::from(registers.len() - 1)
         };
 
-        let equal_cmp_opcode = Opcode::BinaryIntOp {
-            op: BinaryIntOp::Cmp(Comparison::Eq),
-            bit_size: 1,
-            lhs,
-            rhs,
-            destination,
-        };
+        let equal_cmp_opcode =
+            Opcode::BinaryIntOp { op: BinaryIntOp::Equals, bit_size: 1, lhs, rhs, destination };
         opcodes.push(equal_cmp_opcode);
         opcodes.push(Opcode::Jump { location: 2 });
         opcodes.push(Opcode::JumpIf { condition: RegisterIndex::from(2), location: 3 });
 
-        let mut vm = VM::new(Registers { inner: registers }, vec![], opcodes, vec![]);
+        let mut vm = VM::new(Registers::load(registers), vec![], opcodes, vec![]);
 
         let status = vm.process_opcode();
         assert_eq!(status, VMStatus::InProgress);
@@ -401,7 +394,7 @@ mod tests {
         let trap_opcode = Opcode::Trap;
 
         let not_equal_cmp_opcode = Opcode::BinaryFieldOp {
-            op: BinaryFieldOp::Cmp(Comparison::Eq),
+            op: BinaryFieldOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(1),
             destination: RegisterIndex::from(2),
@@ -471,6 +464,7 @@ mod tests {
 
     #[test]
     fn cmp_binary_ops() {
+        let bit_size = 32;
         let input_registers = Registers::load(vec![
             Value::from(2u128),
             Value::from(2u128),
@@ -480,32 +474,32 @@ mod tests {
         ]);
 
         let equal_opcode = Opcode::BinaryIntOp {
-            bit_size: 1,
-            op: BinaryIntOp::Cmp(Comparison::Eq),
+            bit_size,
+            op: BinaryIntOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(1),
             destination: RegisterIndex::from(2),
         };
 
         let not_equal_opcode = Opcode::BinaryIntOp {
-            bit_size: 1,
-            op: BinaryIntOp::Cmp(Comparison::Eq),
+            bit_size,
+            op: BinaryIntOp::Equals,
             lhs: RegisterIndex::from(0),
             rhs: RegisterIndex::from(3),
             destination: RegisterIndex::from(2),
         };
 
         let less_than_opcode = Opcode::BinaryIntOp {
-            bit_size: 1,
-            op: BinaryIntOp::Cmp(Comparison::Lt),
+            bit_size,
+            op: BinaryIntOp::LessThan,
             lhs: RegisterIndex::from(3),
             rhs: RegisterIndex::from(4),
             destination: RegisterIndex::from(2),
         };
 
         let less_than_equal_opcode = Opcode::BinaryIntOp {
-            bit_size: 1,
-            op: BinaryIntOp::Cmp(Comparison::Lte),
+            bit_size,
+            op: BinaryIntOp::LessThanEquals,
             lhs: RegisterIndex::from(3),
             rhs: RegisterIndex::from(4),
             destination: RegisterIndex::from(2),
@@ -552,6 +546,7 @@ mod tests {
         ///         i += 1;
         ///     }
         fn brillig_write_memory(memory: Vec<Value>) -> Vec<Value> {
+            let bit_size = 32;
             let r_i = RegisterIndex::from(0);
             let r_len = RegisterIndex::from(1);
             let r_tmp = RegisterIndex::from(2);
@@ -572,15 +567,15 @@ mod tests {
                     lhs: r_i,
                     op: BinaryIntOp::Add,
                     rhs: r_tmp,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // tmp = i < len
                 Opcode::BinaryIntOp {
                     destination: r_tmp,
                     lhs: r_i,
-                    op: BinaryIntOp::Cmp(Comparison::Lt),
+                    op: BinaryIntOp::LessThan,
                     rhs: r_len,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // if tmp != 0 goto loop_body
                 Opcode::JumpIf { condition: r_tmp, location: start.len() },
@@ -615,6 +610,7 @@ mod tests {
         ///         i += 1;
         ///     }
         fn brillig_sum_memory(memory: Vec<Value>) -> Value {
+            let bit_size = 32;
             let r_i = RegisterIndex::from(0);
             let r_len = RegisterIndex::from(1);
             let r_sum = RegisterIndex::from(2);
@@ -636,7 +632,7 @@ mod tests {
                     lhs: r_sum,
                     op: BinaryIntOp::Add,
                     rhs: r_tmp,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // tmp = 1
                 Opcode::Const { destination: r_tmp, value: 1u128.into() },
@@ -646,15 +642,15 @@ mod tests {
                     lhs: r_i,
                     op: BinaryIntOp::Add,
                     rhs: r_tmp,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // tmp = i < len
                 Opcode::BinaryIntOp {
                     destination: r_tmp,
                     lhs: r_i,
-                    op: BinaryIntOp::Cmp(Comparison::Lt),
+                    op: BinaryIntOp::LessThan,
                     rhs: r_len,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // if tmp != 0 goto loop_body
                 Opcode::JumpIf { condition: r_tmp, location: start.len() },
@@ -688,6 +684,7 @@ mod tests {
         ///     }
         /// Note we represent a 100% in-register optimized form in brillig
         fn brillig_recursive_write_memory(memory: Vec<Value>) -> Vec<Value> {
+            let bit_size = 32;
             let r_i = RegisterIndex::from(0);
             let r_len = RegisterIndex::from(1);
             let r_tmp = RegisterIndex::from(2);
@@ -710,9 +707,9 @@ mod tests {
                 Opcode::BinaryIntOp {
                     destination: r_tmp,
                     lhs: r_len,
-                    op: BinaryIntOp::Cmp(Comparison::Lte),
+                    op: BinaryIntOp::LessThanEquals,
                     rhs: r_i,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // if !tmp, goto end
                 Opcode::JumpIf {
@@ -729,7 +726,7 @@ mod tests {
                     lhs: r_i,
                     op: BinaryIntOp::Add,
                     rhs: r_tmp,
-                    bit_size: 32,
+                    bit_size,
                 },
                 // call recursive_fn
                 Opcode::Call { location: start.len() },

--- a/brillig_vm/src/opcodes.rs
+++ b/brillig_vm/src/opcodes.rs
@@ -114,7 +114,8 @@ pub enum BinaryFieldOp {
     Sub,
     Mul,
     Div,
-    Cmp(Comparison),
+    /// (==) equal
+    Equals,
 }
 
 /// Binary fixed-length integer expressions
@@ -125,7 +126,12 @@ pub enum BinaryIntOp {
     Mul,
     SignedDiv,
     UnsignedDiv,
-    Cmp(Comparison),
+    /// (==) equal
+    Equals,
+    /// (<) Field less than
+    LessThan,
+    /// (<=) field less or equal
+    LessThanEquals,
     /// (&) Bitwise AND
     And,
     /// (|) Bitwise OR
@@ -138,16 +144,6 @@ pub enum BinaryIntOp {
     Shr,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Comparison {
-    /// (==) equal
-    Eq,
-    /// (<) Field less than
-    Lt,
-    /// (<=) field less or equal
-    Lte,
-}
-
 impl BinaryFieldOp {
     /// Evaluate a binary operation on two FieldElements and return the result as a FieldElement.
     pub fn evaluate_field(&self, a: FieldElement, b: FieldElement) -> FieldElement {
@@ -157,12 +153,7 @@ impl BinaryFieldOp {
             BinaryFieldOp::Sub => a - b,
             BinaryFieldOp::Mul => a * b,
             BinaryFieldOp::Div => a / b,
-            // Perform a comparison between a and b based on the Comparison variant.
-            BinaryFieldOp::Cmp(comparison) => match comparison {
-                Comparison::Eq => ((a == b) as u128).into(),
-                Comparison::Lt => ((a < b) as u128).into(),
-                Comparison::Lte => ((a <= b) as u128).into(),
-            },
+            BinaryFieldOp::Equals => (a == b).into(),
         }
     }
 }
@@ -182,12 +173,12 @@ impl BinaryIntOp {
             BinaryIntOp::SignedDiv => {
                 to_unsigned(to_signed(a, bit_size) / to_signed(b, bit_size), bit_size)
             }
-            // Perform a comparison between a and b based on the Comparison variant.
-            BinaryIntOp::Cmp(comparison) => match comparison {
-                Comparison::Eq => (a == b) as u128,
-                Comparison::Lt => (a < b) as u128,
-                Comparison::Lte => (a <= b) as u128,
-            },
+            // Perform a == operation, returning 0 or 1
+            BinaryIntOp::Equals => ((a % bit_modulo) == (b % bit_modulo)).into(),
+            // Perform a < operation, returning 0 or 1
+            BinaryIntOp::LessThan => ((a % bit_modulo) < (b % bit_modulo)).into(),
+            // Perform a <= operation, returning 0 or 1
+            BinaryIntOp::LessThanEquals => ((a % bit_modulo) <= (b % bit_modulo)).into(),
             // Perform bitwise AND, OR, XOR, left shift, and right shift operations, applying a modulo operation to keep the result within the bit size.
             BinaryIntOp::And => (a & b) % bit_modulo,
             BinaryIntOp::Or => (a | b) % bit_modulo,

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -9,6 +9,9 @@ pub struct Registers {
     pub inner: Vec<Option<Value>>,
 }
 
+/// Aims to match a reasonable max register count for a SNARK prover.
+/// As well, catches obvious erroneous use of registers.
+/// This can be revisited if it proves not enough.
 const MAX_REGISTERS: usize = 2_usize.pow(16);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -27,11 +27,13 @@ impl From<usize> for RegisterIndex {
 }
 
 impl Registers {
+    /// Create a Registers object initialized with definite values
     pub fn load(values: Vec<Value>) -> Registers {
         let inner = values.into_iter().map(Some).collect();
         Self { inner }
     }
 
+    /// Gets the values at register with address `index`
     pub fn get(&self, register_index: RegisterIndex) -> Value {
         let index = register_index.to_usize();
         assert!(index < MAX_REGISTERS, "Reading register past maximum!");
@@ -44,14 +46,11 @@ impl Registers {
         self.inner[index].expect("Reading uninitialized register!")
     }
 
+    /// Sets the value at register with address `index` to `value`
     pub fn set(&mut self, RegisterIndex(index): RegisterIndex, value: Value) {
         assert!(index < MAX_REGISTERS, "Writing register past maximum!");
         let new_register_size = std::cmp::max(index + 1, self.inner.len());
         self.inner.resize(new_register_size, None);
         self.inner[index] = Some(value)
-    }
-
-    pub fn values(self) -> Vec<Option<Value>> {
-        self.inner
     }
 }

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -3,9 +3,11 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Registers {
-    // Keep track of registers as an option to represent uninitialized registers
-    // These occur when we set a register value at a noncontiguous index, past currently defined registers
-    // This could just store 0's, but it would be
+    // Registers are a vector of values that might be None.
+    // None is used to mark uninitialized registers so we can catch potential mistakes.
+    // The reasoning is that instead of returning 0, it is much more likely that such an access is a mistake
+    // (e.g. didn't emit the set operation).
+    // We grow the register as registers past the end are set, extending with None's.
     pub inner: Vec<Option<Value>>,
 }
 

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Registers {
     // Keep track of registers as an option to represent uninitialized registers
-    // These occur when we set a register value at an uncontiguous index, past currently defined registers
+    // These occur when we set a register value at a noncontiguous index, past currently defined registers
     // This could just store 0's, but it would be
     pub inner: Vec<Option<Value>>,
 }

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -14,6 +14,7 @@ const MAX_REGISTERS: usize = 2_usize.pow(16);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterIndex(usize);
 
+/// `RegisterIndex` refers to the index in VM register space.
 impl RegisterIndex {
     pub fn to_usize(self) -> usize {
         self.0
@@ -26,6 +27,8 @@ impl From<usize> for RegisterIndex {
     }
 }
 
+/// Registers will store field element values during the
+/// duration of the execution of the bytecode.
 impl Registers {
     /// Create a Registers object initialized with definite values
     pub fn load(values: Vec<Value>) -> Registers {

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -55,6 +55,7 @@ impl Registers {
     /// Sets the value at register with address `index` to `value`
     pub fn set(&mut self, RegisterIndex(index): RegisterIndex, value: Value) {
         assert!(index < MAX_REGISTERS, "Writing register past maximum!");
+        // if size isn't at least index + 1, resize
         let new_register_size = std::cmp::max(index + 1, self.inner.len());
         self.inner.resize(new_register_size, None);
         self.inner[index] = Some(value)

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -1,39 +1,16 @@
 use crate::Value;
 use serde::{Deserialize, Serialize};
 
-/// Registers will store field element values during the
-/// duration of the execution of the bytecode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Registers {
-    pub inner: Vec<Value>,
+    // Keep track of registers as an option to represent uninitialized registers
+    // These occur when we set a register value at an uncontiguous index, past currently defined registers
+    // This could just store 0's, but it would be
+    pub inner: Vec<Option<Value>>,
 }
 
-impl IntoIterator for Registers {
-    type Item = Value;
-    type IntoIter = RegistersIntoIterator;
+const MAX_REGISTERS: usize = 2_usize.pow(16);
 
-    fn into_iter(self) -> Self::IntoIter {
-        RegistersIntoIterator { registers: self, index: 0 }
-    }
-}
-pub struct RegistersIntoIterator {
-    registers: Registers,
-    index: usize,
-}
-
-impl Iterator for RegistersIntoIterator {
-    type Item = Value;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index >= self.registers.inner.len() {
-            return None;
-        }
-
-        self.index += 1;
-        Some(self.registers.inner[self.index - 1])
-    }
-}
-/// `RegisterIndex` refers to the index of a register in the VM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterIndex(usize);
 
@@ -50,30 +27,31 @@ impl From<usize> for RegisterIndex {
 }
 
 impl Registers {
-    /// Contiguously load the register with `values`
     pub fn load(values: Vec<Value>) -> Registers {
-        Self { inner: values }
+        let inner = values.into_iter().map(Some).collect();
+        Self { inner }
     }
 
-    /// Gets the values at register with address `index`
-    pub fn get(&self, register: RegisterIndex) -> Value {
-        self.inner[register.to_usize()]
+    pub fn get(&self, register_index: RegisterIndex) -> Value {
+        let index = register_index.to_usize();
+        assert!(index < MAX_REGISTERS, "Reading register past maximum!");
+        assert!(
+            index < self.inner.len(),
+            "Reading uninitialized register {} (current max index {})!",
+            index,
+            self.inner.len() - 1
+        );
+        self.inner[index].expect("Reading uninitialized register!")
     }
 
-    /// Sets the value at register with address `index` to `value`
-    pub fn set(&mut self, index: RegisterIndex, value: Value) {
-        if index.to_usize() >= self.inner.len() {
-            let diff = index.to_usize() - self.inner.len() + 1;
-            self.inner.extend(vec![Value::from(0u128); diff])
-        }
-        self.inner[index.to_usize()] = value
+    pub fn set(&mut self, RegisterIndex(index): RegisterIndex, value: Value) {
+        assert!(index < MAX_REGISTERS, "Writing register past maximum!");
+        let new_register_size = std::cmp::max(index + 1, self.inner.len());
+        self.inner.resize(new_register_size, None);
+        self.inner[index] = Some(value)
     }
 
-    /// Returns all of the values in the register
-    /// This should be done at the end of the VM
-    /// run and will be useful for mapping the values
-    /// to witness indices
-    pub fn values(self) -> Vec<Value> {
+    pub fn values(self) -> Vec<Option<Value>> {
         self.inner
     }
 }


### PR DESCRIPTION
Resolves #306 #326

# Description

Various fixup changes. Includes a change to try and catch misuses of registers (by having an explicit uninitialized value)

## Summary of changes

Rename resolve_foreign_call_input for #306 
chore: Remove Field < and <= support from Brillig for #326 

## Dependency additions / changes

N/A

## Test additions / changes

Some minor test simplification as field LTE was no longer available

# Checklist

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [ ] I have reviewed the changes on GitHub, line by line.
- [ ] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
