### PR TITLE
fix(brillig): Proper error handling for Brillig failures

### DIFF
--- a/acvm/src/pwg.rs
+++ b/acvm/src/pwg.rs
@@ -87,6 +87,8 @@ pub enum OpcodeResolutionError {
     IncorrectNumFunctionArguments(usize, BlackBoxFunc, usize),
     #[error("failed to solve blackbox function: {0}, reason: {1}")]
     BlackBoxFunctionFailed(BlackBoxFunc, String),
+    #[error("failed to solve brillig function, reason: {0}")]
+    BrilligFunctionFailed(String),
 }
 
 pub fn solve(

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -121,7 +121,9 @@ impl BrilligSolver {
                 OpcodeResolution::Solved
             }
             VMStatus::InProgress => unreachable!("Brillig VM has not completed execution"),
-            VMStatus::Failure => return Err(OpcodeResolutionError::UnsatisfiedConstrain),
+            VMStatus::Failure { message } => {
+                return Err(OpcodeResolutionError::BrilligFunctionFailed(message))
+            }
             VMStatus::ForeignCallWait { function, inputs } => {
                 OpcodeResolution::InProgressBrillig(ForeignCallWaitInfo { function, inputs })
             }

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
         "bivariate",
         "Brillig",
         "canonicalize",
+        "callstack",
         "coeff",
         "consts",
         "csat",
@@ -42,6 +43,8 @@
         "flate",
         "indexmap",
         "thiserror",
-        "typenum"
+        "typenum",
+        "jmpif",
+        "jmpifnot"
     ]
 }


### PR DESCRIPTION
Resolves #305 

# Description
Propagates error messages in failure() to the top of VM resolution
Future improvements would potentially also propagate the trace of 'call' functions (would need some debug-enabling func info data structure in the VM)

# Checklist

- [*] I have tested the changes locally.
- [*] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [*] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [*] I have reviewed the changes on GitHub, line by line.
- [*] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
