### PR TITLE
fix(ci): Add brillig_vm to release-please & link versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
         id: release
         uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.ACVM_RELEASE_TOKEN }}
           command: manifest
 
   publish:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "bootstrap-sha": "97149adb99f53e1f78de6d7ad938f4af262483e6",
   "release-type": "rust",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
@@ -35,6 +34,9 @@
     "acvm": {
       "component": "acvm"
     },
+    "brillig_vm": {
+      "component": "brillig_vm"
+    },
     "stdlib": {
       "component": "acvm_stdlib"
     }
@@ -52,6 +54,7 @@
         "acir",
         "acir_field",
         "acvm",
+        "brillig_vm",
         "acvm_stdlib"
       ]
     }


### PR DESCRIPTION
# Related issue(s)

(If it does not already exist, first create a GitHub issue that describes the problem this Pull Request (PR) solves before creating the PR and link it here.)

Resolves #301

# Description

## Summary of changes

This adds brillig to the release-please config so it can have a linked version and RP will create github releases for it.

I've also updated the release token so CI will run against the release PR.

While I was updating the release-please config, I removed the bootstrap sha that is no longer needed since we've already bootstrapped the project.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [x] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
