### PR TITLE
fix(ci): Correct typo to avoid `undefined` in changelogs

### DIFF
--- a/acir/CHANGELOG.md
+++ b/acir/CHANGELOG.md
@@ -63,14 +63,14 @@
 
 ### Miscellaneous Chores
 
-* **acir:** Synchronize undefined versions
+* **acir:** Synchronize acvm versions
 
 ## [0.10.2](https://github.com/noir-lang/acvm/compare/acir-v0.10.1...acir-v0.10.2) (2023-04-28)
 
 
 ### Miscellaneous Chores
 
-* **acir:** Synchronize undefined versions
+* **acir:** Synchronize acvm versions
 
 ## [0.10.1](https://github.com/noir-lang/acvm/compare/acir-v0.10.0...acir-v0.10.1) (2023-04-28)
 
@@ -129,7 +129,7 @@
 
 ### Miscellaneous Chores
 
-* **acir:** Synchronize undefined versions
+* **acir:** Synchronize acvm versions
 
 ## [0.7.0](https://github.com/noir-lang/acvm/compare/acir-v0.6.0...acir-v0.7.0) (2023-03-23)
 

--- a/acir_field/CHANGELOG.md
+++ b/acir_field/CHANGELOG.md
@@ -5,35 +5,35 @@
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.12.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.11.0...acir_field-v0.12.0) (2023-05-17)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.11.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.10.3...acir_field-v0.11.0) (2023-05-04)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.10.3](https://github.com/noir-lang/acvm/compare/acir_field-v0.10.2...acir_field-v0.10.3) (2023-04-28)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.10.2](https://github.com/noir-lang/acvm/compare/acir_field-v0.10.1...acir_field-v0.10.2) (2023-04-28)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.10.1](https://github.com/noir-lang/acvm/compare/acir_field-v0.10.0...acir_field-v0.10.1) (2023-04-28)
 
@@ -65,42 +65,42 @@
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.8.1](https://github.com/noir-lang/acvm/compare/acir_field-v0.8.0...acir_field-v0.8.1) (2023-03-30)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.8.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.7.1...acir_field-v0.8.0) (2023-03-28)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.7.1](https://github.com/noir-lang/acvm/compare/acir_field-v0.7.0...acir_field-v0.7.1) (2023-03-27)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.7.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.6.0...acir_field-v0.7.0) (2023-03-23)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.6.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.5.0...acir_field-v0.6.0) (2023-03-03)
 
 
 ### Miscellaneous Chores
 
-* **acir_field:** Synchronize undefined versions
+* **acir_field:** Synchronize acvm versions
 
 ## [0.5.0](https://github.com/noir-lang/acvm/compare/acir_field-v0.4.1...acir_field-v0.5.0) (2023-02-22)
 

--- a/acvm/CHANGELOG.md
+++ b/acvm/CHANGELOG.md
@@ -93,14 +93,14 @@
 
 ### Miscellaneous Chores
 
-* **acvm:** Synchronize undefined versions
+* **acvm:** Synchronize acvm versions
 
 ## [0.10.1](https://github.com/noir-lang/acvm/compare/acvm-v0.10.0...acvm-v0.10.1) (2023-04-28)
 
 
 ### Miscellaneous Chores
 
-* **acvm:** Synchronize undefined versions
+* **acvm:** Synchronize acvm versions
 
 ## [0.10.0](https://github.com/noir-lang/acvm/compare/acvm-v0.9.0...acvm-v0.10.0) (2023-04-26)
 
@@ -157,14 +157,14 @@
 
 ### Miscellaneous Chores
 
-* **acvm:** Synchronize undefined versions
+* **acvm:** Synchronize acvm versions
 
 ## [0.8.0](https://github.com/noir-lang/acvm/compare/acvm-v0.7.1...acvm-v0.8.0) (2023-03-28)
 
 
 ### Miscellaneous Chores
 
-* **acvm:** Synchronize undefined versions
+* **acvm:** Synchronize acvm versions
 
 ## [0.7.1](https://github.com/noir-lang/acvm/compare/acvm-v0.7.0...acvm-v0.7.1) (2023-03-27)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -48,7 +48,7 @@
     },
     {
       "type": "linked-versions",
-      "group-name": "acvm",
+      "groupName": "acvm",
       "components": [
         "root",
         "acir",

--- a/stdlib/CHANGELOG.md
+++ b/stdlib/CHANGELOG.md
@@ -5,28 +5,28 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 ## [0.12.0](https://github.com/noir-lang/acvm/compare/acvm_stdlib-v0.11.0...acvm_stdlib-v0.12.0) (2023-05-17)
 
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 ## [0.11.0](https://github.com/noir-lang/acvm/compare/acvm_stdlib-v0.10.3...acvm_stdlib-v0.11.0) (2023-05-04)
 
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 ## [0.10.3](https://github.com/noir-lang/acvm/compare/acvm_stdlib-v0.10.2...acvm_stdlib-v0.10.3) (2023-04-28)
 
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 ## [0.10.2](https://github.com/noir-lang/acvm/compare/acvm_stdlib-v0.10.1...acvm_stdlib-v0.10.2) (2023-04-28)
 
@@ -40,7 +40,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 ## [0.10.0](https://github.com/noir-lang/acvm/compare/acvm_stdlib-v0.9.0...acvm_stdlib-v0.10.0) (2023-04-26)
 
@@ -63,7 +63,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 
 ### Dependencies
@@ -77,7 +77,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 
 ### Dependencies
@@ -91,7 +91,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 
 ### Dependencies
@@ -105,7 +105,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 
 ### Dependencies
@@ -119,7 +119,7 @@
 
 ### Miscellaneous Chores
 
-* **acvm_stdlib:** Synchronize undefined versions
+* **acvm_stdlib:** Synchronize acvm versions
 
 
 ### Dependencies


### PR DESCRIPTION
# Related issue(s)

# Description

## Summary of changes

I noticed that `undefined` was being output into our changelogs. This should fix it—I had made a typo with the property name for the plugin.

I also updated the changelogs.

## Dependency additions / changes

(If applicable.)

## Test additions / changes

(If applicable.)

# Checklist

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` with default settings.
- [ ] I have [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) this PR to the issue(s) that it resolves.
- [x] I have reviewed the changes on GitHub, line by line.
- [x] I have ensured all changes are covered in the description.

# Additional context

(If applicable.)
