### PR TITLE
chore: Revert "fix: re-use intermediate vars during width reduction"

### DIFF
--- a/acir/src/native_types/expression/mod.rs
+++ b/acir/src/native_types/expression/mod.rs
@@ -13,7 +13,7 @@ mod ordering;
 //
 // In the multiplication polynomial
 // XXX: If we allow the degree of the quotient polynomial to be arbitrary, then we will need a vector of wire values
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Expression {
     // To avoid having to create intermediate variables pre-optimization
     // We collect all of the multiplication terms in the arithmetic gate

--- a/acvm/src/compiler.rs
+++ b/acvm/src/compiler.rs
@@ -6,7 +6,7 @@ use crate::Language;
 use acir::{
     circuit::{Circuit, Opcode},
     native_types::{Expression, Witness},
-    BlackBoxFunc, FieldElement,
+    BlackBoxFunc,
 };
 use indexmap::IndexMap;
 use optimizers::GeneralOptimizer;
@@ -68,30 +68,23 @@ pub fn compile(
     let mut transformed_gates = Vec::new();
 
     let mut next_witness_index = acir.current_witness_index + 1;
-    // maps a normalized expression to the intermediate variable which represents the expression, along with its 'norm'
-    // the 'norm' is simply the value of the first non zero coefficient in the expression, taken from the linear terms, or quadratic terms if there is none.
-    let mut intermediate_variables: IndexMap<Expression, (FieldElement, Witness)> = IndexMap::new();
     for opcode in acir.opcodes {
         match opcode {
             Opcode::Arithmetic(arith_expr) => {
-                let len = intermediate_variables.len();
+                let mut intermediate_variables: IndexMap<Witness, Expression> = IndexMap::new();
 
                 let arith_expr = transformer.transform(
                     arith_expr,
                     &mut intermediate_variables,
-                    &mut next_witness_index,
+                    next_witness_index,
                 );
 
                 // Update next_witness counter
-                next_witness_index += (intermediate_variables.len() - len) as u32;
+                next_witness_index += intermediate_variables.len() as u32;
                 let mut new_gates = Vec::new();
-                for (g, (norm, w)) in intermediate_variables.iter().skip(len) {
-                    // de-normalize
-                    let mut intermediate_gate = g * *norm;
-                    // constrain the intermediate gate to the intermediate variable
-                    intermediate_gate.linear_combinations.push((-FieldElement::one(), *w));
-                    intermediate_gate.sort();
-                    new_gates.push(intermediate_gate);
+                for (_, mut g) in intermediate_variables {
+                    g.sort();
+                    new_gates.push(g);
                 }
                 new_gates.push(arith_expr);
                 new_gates.sort();

--- a/acvm/src/compiler/transformers/csat.rs
+++ b/acvm/src/compiler/transformers/csat.rs
@@ -27,8 +27,8 @@ impl CSatTransformer {
     pub fn transform(
         &self,
         gate: Expression,
-        intermediate_variables: &mut IndexMap<Expression, (FieldElement, Witness)>,
-        num_witness: &mut u32,
+        intermediate_variables: &mut IndexMap<Witness, Expression>,
+        num_witness: u32,
     ) -> Expression {
         // Here we create intermediate variables and constrain them to be equal to any subset of the polynomial that can be represented as a full gate
         let gate = self.full_gate_scan_optimization(gate, intermediate_variables, num_witness);
@@ -68,8 +68,8 @@ impl CSatTransformer {
     fn full_gate_scan_optimization(
         &self,
         mut gate: Expression,
-        intermediate_variables: &mut IndexMap<Expression, (FieldElement, Witness)>,
-        num_witness: &mut u32,
+        intermediate_variables: &mut IndexMap<Witness, Expression>,
+        num_witness: u32,
     ) -> Expression {
         // We pass around this intermediate variable IndexMap, so that we do not create intermediate variables that we have created before
         // One instance where this might happen is t1 = wL * wR and t2 = wR * wL
@@ -165,12 +165,12 @@ impl CSatTransformer {
                     // XXX: Another optimization, which could be applied in another algorithm
                     // If two gates have a large fan-in/out and they share a few common terms, then we should create intermediate variables for them
                     // Do some sort of subset matching algorithm for this on the terms of the polynomial
+                    let inter_var = Witness(intermediate_variables.len() as u32 + num_witness);
 
-                    let inter_var = Self::get_or_create_intermediate_vars(
-                        intermediate_variables,
-                        intermediate_gate,
-                        num_witness,
-                    );
+                    // Constrain the gate to the intermediate variable
+                    intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
+                    // Add intermediate gate to the map
+                    intermediate_variables.insert(inter_var, intermediate_gate);
 
                     // Add intermediate variable to the new gate instead of the full gate
                     new_gate.linear_combinations.push((FieldElement::one(), inter_var));
@@ -186,41 +186,6 @@ impl CSatTransformer {
         new_gate.q_c = gate.q_c;
         new_gate.sort();
         new_gate
-    }
-
-    /// Normalize an expression by dividing it by its first coefficient
-    /// The first coefficient here means coefficient of the first linear term, or of the first quadratic term if no linear terms exist.
-    /// The function panic if the input expression is constant
-    fn normalize(mut expr: Expression) -> (FieldElement, Expression) {
-        expr.sort();
-        let a = if !expr.linear_combinations.is_empty() {
-            expr.linear_combinations[0].0
-        } else {
-            expr.mul_terms[0].0
-        };
-        (a, &expr * a.inverse())
-    }
-
-    /// Get or generate a witness which is equal to the provided expression
-    /// The sets of previously generated witness and their (normalized) expression is cached in the intermediate_variables map
-    /// If there is no cache hit, we generate a new witness (and add the expression to the cache)
-    /// else, we return the cached witness
-    fn get_or_create_intermediate_vars(
-        intermediate_variables: &mut IndexMap<Expression, (FieldElement, Witness)>,
-        expr: Expression,
-        num_witness: &mut u32,
-    ) -> Witness {
-        let (l, normalized_expr) = Self::normalize(expr);
-
-        if intermediate_variables.contains_key(&normalized_expr) {
-            intermediate_variables[&normalized_expr].1
-        } else {
-            let inter_var = Witness(*num_witness);
-            *num_witness += 1;
-            // Add intermediate gate and variable to map
-            intermediate_variables.insert(normalized_expr, (l, inter_var));
-            inter_var
-        }
     }
 
     // A partial gate scan optimization aim to create intermediate variables in order to compress the polynomial
@@ -263,8 +228,8 @@ impl CSatTransformer {
     fn partial_gate_scan_optimization(
         &self,
         mut gate: Expression,
-        intermediate_variables: &mut IndexMap<Expression, (FieldElement, Witness)>,
-        num_witness: &mut u32,
+        intermediate_variables: &mut IndexMap<Witness, Expression>,
+        num_witness: u32,
     ) -> Expression {
         // We will go for the easiest route, which is to convert all multiplications into additions using intermediate variables
         // Then use intermediate variables again to squash the fan-in, so that it can fit into the appropriate width
@@ -277,16 +242,17 @@ impl CSatTransformer {
 
         // 2. Create Intermediate variables for the multiplication gates
         for mul_term in gate.mul_terms.clone().into_iter() {
+            // Create intermediate variable to squash the multiplication term
+            let inter_var = Witness((intermediate_variables.len() as u32) + num_witness);
             let mut intermediate_gate = Expression::default();
 
             // Push mul term into the gate
             intermediate_gate.mul_terms.push(mul_term);
-            // Get an intermediate variable which squashes the multiplication term
-            let inter_var = Self::get_or_create_intermediate_vars(
-                intermediate_variables,
-                intermediate_gate,
-                num_witness,
-            );
+            // Constrain it to be equal to the intermediate variable
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
+
+            // Add intermediate gate and variable to map
+            intermediate_variables.insert(inter_var, intermediate_gate);
 
             // Add intermediate variable as a part of the fan-in for the original gate
             gate.linear_combinations.push((FieldElement::one(), inter_var));
@@ -321,13 +287,15 @@ impl CSatTransformer {
                     }
                 };
             }
-            let inter_var = Self::get_or_create_intermediate_vars(
-                intermediate_variables,
-                intermediate_gate,
-                num_witness,
-            );
+            // Constrain the intermediate gate to be equal to the intermediate variable
+            let inter_var = Witness((intermediate_variables.len() as u32) + num_witness);
 
             added.push((FieldElement::one(), inter_var));
+
+            intermediate_gate.linear_combinations.push((-FieldElement::one(), inter_var));
+
+            // Add intermediate gate and variable to map
+            intermediate_variables.insert(inter_var, intermediate_gate);
         }
 
         // Add back the intermediate variables to
@@ -357,13 +325,13 @@ fn simple_reduction_smoke_test() {
         q_c: FieldElement::zero(),
     };
 
-    let mut intermediate_variables: IndexMap<Expression, (FieldElement, Witness)> = IndexMap::new();
+    let mut intermediate_variables: IndexMap<Witness, Expression> = IndexMap::new();
 
-    let mut num_witness = 4;
+    let num_witness = 4;
 
     let optimizer = CSatTransformer::new(3);
     let got_optimized_gate_a =
-        optimizer.transform(gate_a, &mut intermediate_variables, &mut num_witness);
+        optimizer.transform(gate_a, &mut intermediate_variables, num_witness);
 
     // a = b + c + d => a - b - c - d = 0
     // For width3, the result becomes:
@@ -385,13 +353,17 @@ fn simple_reduction_smoke_test() {
 
     assert_eq!(intermediate_variables.len(), 1);
 
-    // e = - c - d
+    let got_intermediate_gate = intermediate_variables.get(&e).unwrap();
+
+    // - c - d  - e = 0
     let expected_intermediate_gate = Expression {
         mul_terms: vec![],
-        linear_combinations: vec![(-FieldElement::one(), d), (-FieldElement::one(), c)],
+        linear_combinations: vec![
+            (-FieldElement::one(), d),
+            (-FieldElement::one(), c),
+            (-FieldElement::one(), e),
+        ],
         q_c: FieldElement::zero(),
     };
-    let (_, normalized_gate) = CSatTransformer::normalize(expected_intermediate_gate);
-    assert!(intermediate_variables.contains_key(&normalized_gate));
-    assert_eq!(intermediate_variables[&normalized_gate].1, e);
+    assert_eq!(&expected_intermediate_gate, got_intermediate_gate);
 }


### PR DESCRIPTION
Reverts noir-lang/acvm#278

Putting this PR up as it seems to be breaking here: https://github.com/noir-lang/noir/pull/1509