### PR TITLE
fix(brillig): expand memory with zeroes on store

### DIFF
--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -225,7 +225,10 @@ impl VM {
                 // Convert our destination_pointer to a usize
                 let destination = self.registers.get(*destination_pointer).to_usize();
                 if destination >= self.memory.len() {
-                    self.memory.append(&mut vec![Value::from(0_usize); destination - self.memory.len() + 1]);
+                    self.memory.append(&mut vec![
+                        Value::from(0_usize);
+                        destination - self.memory.len() + 1
+                    ]);
                 }
                 // Use our usize destination index to set the value in memory
                 self.memory[destination] = self.registers.get(*source_register);

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -223,9 +223,12 @@ impl VM {
             }
             Opcode::Store { destination_pointer, source: source_register } => {
                 // Convert our destination_pointer to a usize
-                let destination = self.registers.get(*destination_pointer);
+                let destination = self.registers.get(*destination_pointer).to_usize();
+                if destination >= self.memory.len() {
+                    self.memory.append(&mut vec![Value::from(0_usize); destination - self.memory.len() + 1]);
+                }
                 // Use our usize destination index to set the value in memory
-                self.memory[destination.to_usize()] = self.registers.get(*source_register);
+                self.memory[destination] = self.registers.get(*source_register);
                 self.increment_program_counter()
             }
             Opcode::Call { location } => {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Brillig VM memory was fixed on initialization, which requires to always initialize it with an empty memory of the maximum size allowed.  

## Summary\*
<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR expands the memory dynamically on store with zeroes. In the future we can add a feature of passing a maximum memory on VM creation to limit VM memory for applications where brillig is going to be verified with constrained resources, such as in a VM circuit.

### Example

<!-- Code / step-by-step example(s) to demonstrate the effect of this PR. -->

Before:

```

```

After:

```

```

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
