### PR TITLE
chore: clean up ECDSA verification logic

### DIFF
--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -27,6 +27,17 @@ pub(crate) fn secp256k1_prehashed(
     hashed_message_inputs: &[FunctionInput],
     output: Witness,
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+    let hashed_message: [u8; 32] =
+        to_u8_vec(initial_witness, hashed_message_inputs)?.try_into().map_err(|_| {
+            OpcodeResolutionError::BlackBoxFunctionFailed(
+                acir::BlackBoxFunc::EcdsaSecp256k1,
+                format!(
+                    "expected hashed message size 32 but received {}",
+                    hashed_message_inputs.len()
+                ),
+            )
+        })?;
+
     let pub_key_x: [u8; 32] =
         to_u8_vec(initial_witness, public_key_x_inputs)?.try_into().map_err(|_| {
             OpcodeResolutionError::BlackBoxFunctionFailed(
@@ -51,7 +62,6 @@ pub(crate) fn secp256k1_prehashed(
             )
         })?;
 
-    let hashed_message = to_u8_vec(initial_witness, hashed_message_inputs)?;
     let result =
         ecdsa_secp256k1::verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature)
             .is_ok();
@@ -61,10 +71,6 @@ pub(crate) fn secp256k1_prehashed(
 }
 
 mod ecdsa_secp256k1 {
-    use std::convert::TryInto;
-
-    use blake2::digest::generic_array::GenericArray;
-
     use k256::elliptic_curve::sec1::FromEncodedPoint;
     use k256::elliptic_curve::PrimeField;
 
@@ -89,9 +95,8 @@ mod ecdsa_secp256k1 {
         let message =
             b"ECDSA proves knowledge of a secret number in the context of a single message";
 
-        let mut hasher = Sha256::new();
-        hasher.update(message);
-        let digest = hasher.finalize();
+        let digest: [u8; 32] =
+            Sha256::digest(message).try_into().expect("SHA256 digest should be 256 bits");
 
         let signature: Signature = signing_key.sign(message);
         // Verification
@@ -101,9 +106,13 @@ mod ecdsa_secp256k1 {
 
         if let Coordinates::Uncompressed { x, y } = verify_key.to_encoded_point(false).coordinates()
         {
-            let signature_bytes: &[u8] = signature.as_ref();
-            assert!(Signature::try_from(signature_bytes).unwrap() == signature);
-            verify_prehashed(&digest, x, y, signature_bytes).unwrap();
+            let signature_bytes: [u8; 64] = signature.as_ref().try_into().unwrap();
+            assert!(Signature::try_from(signature_bytes.as_slice()).unwrap() == signature);
+
+            let x: [u8; 32] = x.clone().into();
+            let y: [u8; 32] = y.clone().into();
+
+            verify_prehashed(&digest, &x, &y, &signature_bytes).unwrap();
         } else {
             unreachable!();
         }
@@ -113,32 +122,23 @@ mod ecdsa_secp256k1 {
 
     /// Verify an ECDSA signature, given the hashed message
     pub(super) fn verify_prehashed(
-        hashed_msg: &[u8],
-        public_key_x_bytes: &[u8],
-        public_key_y_bytes: &[u8],
-        signature: &[u8],
+        hashed_msg: &[u8; 32],
+        public_key_x_bytes: &[u8; 32],
+        public_key_y_bytes: &[u8; 32],
+        signature: &[u8; 64],
     ) -> Result<(), ()> {
         // Convert the inputs into k256 data structures
 
-        let signature = Signature::try_from(signature).unwrap();
-
-        let pub_key_x_arr: [u8; 32] = {
-            let pub_key_x_bytes: &[u8] = public_key_x_bytes;
-            pub_key_x_bytes.try_into().unwrap()
-        };
-        let pub_key_y_arr: [u8; 32] = {
-            let pub_key_y_bytes: &[u8] = public_key_y_bytes;
-            pub_key_y_bytes.try_into().unwrap()
-        };
+        let signature = Signature::try_from(signature.as_slice()).unwrap();
 
         let point = EncodedPoint::from_affine_coordinates(
-            &pub_key_x_arr.into(),
-            &pub_key_y_arr.into(),
+            public_key_x_bytes.into(),
+            public_key_y_bytes.into(),
             true,
         );
         let pubkey = PublicKey::from_encoded_point(&point).unwrap();
 
-        let z = Scalar::from_repr(*GenericArray::from_slice(hashed_msg)).unwrap();
+        let z = Scalar::from_repr((*hashed_msg).into()).unwrap();
 
         // Finished converting bytes into data structures
 

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -101,11 +101,6 @@ fn verify_prehashed(
         return Err(());
     }
 
-    // Ensure signature is "low S" normalized ala BIP 0062
-    if s.is_high().into() {
-        return Err(());
-    }
-
     let s_inv = s.invert().unwrap();
     let u1 = z * s_inv;
     let u2 = *r * s_inv;

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -128,49 +128,7 @@ fn verify_prehashed(
 
 #[cfg(test)]
 mod test {
-
-    use k256::ecdsa::Signature;
-    use k256::elliptic_curve::sec1::{Coordinates, ToEncodedPoint};
-
     use super::verify_prehashed;
-
-    // This method is used to generate test vectors
-    // in noir. TODO: check that it is indeed used
-    #[allow(dead_code)]
-    fn generate_proof_data() {
-        use k256::ecdsa::{signature::Signer, SigningKey};
-
-        use sha2::{Digest, Sha256};
-
-        // Signing
-        let signing_key = SigningKey::from_bytes(&[2u8; 32]).unwrap();
-        let message =
-            b"ECDSA proves knowledge of a secret number in the context of a single message";
-
-        let digest: [u8; 32] =
-            Sha256::digest(message).try_into().expect("SHA256 digest should be 256 bits");
-
-        let signature: Signature = signing_key.sign(message);
-        let signature_bytes: [u8; 64] = signature.as_ref().try_into().unwrap();
-        assert!(Signature::try_from(signature_bytes.as_slice()).unwrap() == signature);
-
-        // Verification
-        use k256::ecdsa::{signature::Verifier, VerifyingKey};
-
-        let verify_key = VerifyingKey::from(&signing_key);
-
-        if let Coordinates::Uncompressed { x, y } = verify_key.to_encoded_point(false).coordinates()
-        {
-            let x: [u8; 32] = (*x).into();
-            let y: [u8; 32] = (*y).into();
-
-            verify_prehashed(&digest, &x, &y, &signature_bytes).unwrap();
-        } else {
-            unreachable!();
-        }
-
-        assert!(verify_key.verify(message, &signature).is_ok());
-    }
 
     #[test]
     fn smoke() {

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -131,7 +131,7 @@ mod test {
     use super::verify_prehashed;
 
     #[test]
-    fn verifies_valid_signature() {
+    fn verifies_valid_signature_with_low_s_value() {
         // 0x3a73f4123a5cd2121f21cd7e8d358835476949d035d9c2da6806b4633ac8c1e2,
         let hashed_message: [u8; 32] = [
             0x3a, 0x73, 0xf4, 0x12, 0x3a, 0x5c, 0xd2, 0x12, 0x1f, 0x21, 0xcd, 0x7e, 0x8d, 0x35,

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -131,7 +131,7 @@ mod test {
     use super::verify_prehashed;
 
     #[test]
-    fn smoke() {
+    fn verifies_valid_signature() {
         // 0x3a73f4123a5cd2121f21cd7e8d358835476949d035d9c2da6806b4633ac8c1e2,
         let hashed_message: [u8; 32] = [
             0x3a, 0x73, 0xf4, 0x12, 0x3a, 0x5c, 0xd2, 0x12, 0x1f, 0x21, 0xcd, 0x7e, 0x8d, 0x35,

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -65,14 +65,16 @@ pub(super) fn secp256k1_prehashed(
             )
         })?;
 
-    let result = verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature).is_ok();
+    let result =
+        verify_secp256k1_ecdsa_signature(&hashed_message, &pub_key_x, &pub_key_y, &signature)
+            .is_ok();
 
     initial_witness.insert(output, FieldElement::from(result));
     Ok(OpcodeResolution::Solved)
 }
 
-/// Verify an ECDSA signature, given the hashed message
-fn verify_prehashed(
+/// Verify an ECDSA signature over the secp256k1 elliptic curve, given the hashed message
+fn verify_secp256k1_ecdsa_signature(
     hashed_msg: &[u8],
     public_key_x_bytes: &[u8; 32],
     public_key_y_bytes: &[u8; 32],
@@ -120,7 +122,7 @@ fn verify_prehashed(
 
 #[cfg(test)]
 mod test {
-    use super::verify_prehashed;
+    use super::verify_secp256k1_ecdsa_signature;
 
     #[test]
     fn verifies_valid_signature_with_low_s_value() {
@@ -154,7 +156,9 @@ mod test {
             0x01, 0x61, 0xe4, 0x9a, 0x71, 0x5f, 0xcd, 0x55,
         ];
 
-        let valid = verify_prehashed(&hashed_message, &pub_key_x, &pub_key_y, &signature).is_ok();
+        let valid =
+            verify_secp256k1_ecdsa_signature(&hashed_message, &pub_key_x, &pub_key_y, &signature)
+                .is_ok();
 
         assert!(valid)
     }

--- a/acvm/src/pwg/blackbox/ecdsa.rs
+++ b/acvm/src/pwg/blackbox/ecdsa.rs
@@ -99,6 +99,9 @@ mod ecdsa_secp256k1 {
             Sha256::digest(message).try_into().expect("SHA256 digest should be 256 bits");
 
         let signature: Signature = signing_key.sign(message);
+        let signature_bytes: [u8; 64] = signature.as_ref().try_into().unwrap();
+        assert!(Signature::try_from(signature_bytes.as_slice()).unwrap() == signature);
+
         // Verification
         use k256::ecdsa::{signature::Verifier, VerifyingKey};
 
@@ -106,11 +109,8 @@ mod ecdsa_secp256k1 {
 
         if let Coordinates::Uncompressed { x, y } = verify_key.to_encoded_point(false).coordinates()
         {
-            let signature_bytes: [u8; 64] = signature.as_ref().try_into().unwrap();
-            assert!(Signature::try_from(signature_bytes.as_slice()).unwrap() == signature);
-
-            let x: [u8; 32] = x.clone().into();
-            let y: [u8; 32] = y.clone().into();
+            let x: [u8; 32] = (*x).into();
+            let y: [u8; 32] = (*y).into();
 
             verify_prehashed(&digest, &x, &y, &signature_bytes).unwrap();
         } else {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Merge after #359 

## Summary\*

This PR removes the unnecessary `ecdsa_secp256k1` submodule and deletes dead code.

### Example


## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
