### PR TITLE
feat: add method to generate the new `Brillig` opcode from `UnresolvedBrilligCall`

### DIFF
--- a/acir/src/circuit/brillig.rs
+++ b/acir/src/circuit/brillig.rs
@@ -22,8 +22,10 @@ pub enum BrilligOutputs {
 pub struct Brillig {
     pub inputs: Vec<BrilligInputs>,
     pub outputs: Vec<BrilligOutputs>,
-    /// Results of oracles/functions external to brillig like a database read
+    /// Results of oracles/functions external to brillig like a database read.
+    // Each element of this vector corresponds to a single foreign call but may contain several values.
     pub foreign_call_results: Vec<ForeignCallResult>,
+    /// The Brillig VM bytecode to be executed by this ACIR opcode.
     pub bytecode: Vec<brillig_vm::Opcode>,
     /// Predicate of the Brillig execution - indicates if it should be skipped
     pub predicate: Option<Expression>,

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -533,14 +533,17 @@ mod tests {
         assert_eq!(unsolved_opcodes.len(), 0, "brillig should have been removed");
         assert_eq!(unresolved_brillig_calls.len(), 1, "should have a brillig oracle request");
 
-        let UnresolvedBrilligCall { foreign_call_wait_info, mut brillig } =
-            unresolved_brillig_calls.remove(0);
-        assert_eq!(foreign_call_wait_info.inputs.len(), 1, "Should be waiting for a single input");
+        let foreign_call = unresolved_brillig_calls.remove(0);
+        assert_eq!(
+            foreign_call.foreign_call_wait_info.inputs.len(),
+            1,
+            "Should be waiting for a single input"
+        );
         // As caller of VM, need to resolve foreign calls
+        let foreign_call_result =
+            vec![Value::from(foreign_call.foreign_call_wait_info.inputs[0].to_field().inverse())];
         // Alter Brillig oracle opcode with foreign call resolution
-        brillig.foreign_call_results.push(ForeignCallResult {
-            values: vec![Value::from(foreign_call_wait_info.inputs[0].to_field().inverse())],
-        });
+        let brillig = foreign_call.resolve_foreign_call(foreign_call_result.into());
         let mut next_opcodes_for_solving = vec![Opcode::Brillig(brillig)];
         next_opcodes_for_solving.extend_from_slice(&unsolved_opcodes[..]);
         // After filling data request, continue solving

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -47,6 +47,12 @@ pub struct ForeignCallResult {
     pub values: Vec<Value>,
 }
 
+impl From<Vec<Value>> for ForeignCallResult {
+    fn from(values: Vec<Value>) -> Self {
+        ForeignCallResult { values }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 /// VM encapsulates the state of the Brillig VM during execution.
 pub struct VM {

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -38,9 +38,12 @@ pub enum VMStatus {
     },
 }
 
+/// Represents the output of a [foreign call][Opcode::ForeignCall].
+///
+/// See [`VMStatus::ForeignCallWait`] for more information.
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct ForeignCallResult {
-    /// Resolved foreign call values
+    /// Resolved output values of the foreign call.
     pub values: Vec<Value>,
 }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR aims to smooth out the devex of resolving a brillig foreign call by providing a helper function to generate an updated `Brillig` using the returned call result.

This allows us to use the snippet below

```rust
let result: ForeignCallResult = Oracle::do_brillig_foreign_call(unresolved_brillig_call.foreign_call_wait_info);
let new_brillig: Brillig = unresolved_brillig_call.resolve_foreign_call(result);
opcodes.push(Opcode::Brillig(new_brillig))
```

as opposed to having to extract the `Brillig` struct from the foreign call and manually push a new `ForeignCallResult` onto one of its fields.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
