### PR TITLE
chore: add repository link to `Cargo.toml` metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["The Noir Team <team@noir-lang.org>"]
 edition = "2021"
 license = "MIT"
 rust-version = "1.66"
+repository = "https://github.com/noir-lang/acvm/"
 
 [workspace.dependencies]
 acir = { version = "0.14.2", path = "acir", default-features = false }

--- a/acir/Cargo.toml
+++ b/acir/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/acir_field/Cargo.toml
+++ b/acir_field/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/brillig_vm/Cargo.toml
+++ b/brillig_vm/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/stdlib/Cargo.toml
+++ b/stdlib/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Partial addresses warning at: https://github.com/noir-lang/acvm/actions/runs/5212404733/jobs/9405951422#step:5:11

## Summary\*

We currently don't provide a repository link, homepage or documentation link. This PR adds a repo link so https://crates.io/crates/acvm links back here.

I've left off homepage/documentation as we don't have any ACVM resources currently.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
