### PR TITLE
chore: Remove unnecessary mutability from `BrilligSolver`

### DIFF
--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -14,7 +14,7 @@ pub(super) struct BrilligSolver;
 impl BrilligSolver {
     pub(super) fn solve(
         initial_witness: &mut WitnessMap,
-        brillig: &mut Brillig,
+        brillig: &Brillig,
     ) -> Result<OpcodeResolution, OpcodeResolutionError> {
         // If the predicate is `None`, then we simply return the value 1
         // If the predicate is `Some` but we cannot find a value, then we return stalled

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -32,19 +32,7 @@ impl BrilligSolver {
 
         // A zero predicate indicates the oracle should be skipped, and its outputs zeroed.
         if pred_value.is_zero() {
-            for output in &brillig.outputs {
-                match output {
-                    BrilligOutputs::Simple(witness) => {
-                        insert_value(witness, FieldElement::zero(), initial_witness)?
-                    }
-                    BrilligOutputs::Array(witness_arr) => {
-                        for w in witness_arr {
-                            insert_value(w, FieldElement::zero(), initial_witness)?
-                        }
-                    }
-                }
-            }
-            return Ok(OpcodeResolution::Solved);
+            return Self::zero_out_brillig_outputs(initial_witness, brillig);
         }
 
         // Set input values
@@ -130,6 +118,26 @@ impl BrilligSolver {
         };
 
         Ok(result)
+    }
+
+    /// Assigns the zero value to all outputs of the given [`Brillig`] bytecode.
+    fn zero_out_brillig_outputs(
+        initial_witness: &mut WitnessMap,
+        brillig: &Brillig,
+    ) -> Result<OpcodeResolution, OpcodeResolutionError> {
+        for output in &brillig.outputs {
+            match output {
+                BrilligOutputs::Simple(witness) => {
+                    insert_value(witness, FieldElement::zero(), initial_witness)?
+                }
+                BrilligOutputs::Array(witness_arr) => {
+                    for w in witness_arr {
+                        insert_value(w, FieldElement::zero(), initial_witness)?
+                    }
+                }
+            }
+        }
+        Ok(OpcodeResolution::Solved)
     }
 }
 

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -128,9 +128,8 @@ pub fn solve(
                     Ok(result)
                 }
                 Opcode::Brillig(brillig) => {
-                    let mut brillig_clone = brillig.clone();
-                    let result = BrilligSolver::solve(initial_witness, &mut brillig_clone);
-                    solved_brillig_data = Some(brillig_clone);
+                    let result = BrilligSolver::solve(initial_witness, &brillig);
+                    solved_brillig_data = Some(brillig.clone());
                     result
                 }
             };

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -111,7 +111,6 @@ pub fn solve(
         let mut opcode_not_solvable = None;
         for opcode in &opcode_to_solve {
             let mut solved_oracle_data = None;
-            let mut solved_brillig_data = None;
             let resolution = match opcode {
                 Opcode::Arithmetic(expr) => ArithmeticSolver::solve(initial_witness, expr),
                 Opcode::BlackBoxFuncCall(bb_func) => {
@@ -127,11 +126,7 @@ pub fn solve(
                     solved_oracle_data = Some(data_clone);
                     Ok(result)
                 }
-                Opcode::Brillig(brillig) => {
-                    let result = BrilligSolver::solve(initial_witness, &brillig);
-                    solved_brillig_data = Some(brillig.clone());
-                    result
-                }
+                Opcode::Brillig(brillig) => BrilligSolver::solve(initial_witness, brillig),
             };
             match resolution {
                 Ok(OpcodeResolution::Solved) => {
@@ -168,8 +163,6 @@ pub fn solve(
                     // relies on a later opcodes' results
                     if let Some(oracle_data) = solved_oracle_data {
                         unresolved_opcodes.push(Opcode::Oracle(oracle_data));
-                    } else if let Some(brillig) = solved_brillig_data {
-                        unresolved_opcodes.push(Opcode::Brillig(brillig));
                     } else {
                         unresolved_opcodes.push(opcode.clone());
                     }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Groundwork PR for #384 

## Summary\*

We were including unnecessary mutability for the `Brillig` reference being passed to the `BrilligSolver`. If we make this immutable then we can treat brillig opcodes identically to non-oracle opcodes in the `OpcodeResolution::Stalled` condition.

I've also factored out a function to zero out all the outputs from a brillig opcode for readability-sake.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
