### PR TITLE
chore: fix clippy issues in `brillig_vm`

### DIFF
--- a/brillig_vm/Cargo.toml
+++ b/brillig_vm/Cargo.toml
@@ -13,7 +13,6 @@ repository.workspace = true
 [dependencies]
 acir_field.workspace = true
 serde.workspace = true
-num-bigint.workspace = true
 
 [features]
 default = ["bn254"]

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -1,3 +1,6 @@
+#![warn(unused_crate_dependencies)]
+#![warn(unreachable_pub)]
+
 //! The Brillig VM is a specialized VM which allows the [ACVM][acvm] to perform custom non-determinism.
 //!
 //! Brillig bytecode is distinct from regular [ACIR][acir] in that it does not generate constraints.
@@ -10,8 +13,8 @@ mod opcodes;
 mod registers;
 mod value;
 
-pub use opcodes::Opcode;
 pub use opcodes::{BinaryFieldOp, BinaryIntOp, RegisterOrMemory};
+pub use opcodes::{Label, Opcode};
 pub use registers::{RegisterIndex, Registers};
 use serde::{Deserialize, Serialize};
 pub use value::Typ;


### PR DESCRIPTION
# Description

## Problem\*

## Summary\*

`brillig_vm` didn't have the linting setup from other crates which resulted in an unnecessary dependency and an unreachable export.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
