### PR TITLE
feat!: add trait for witness & make output of mul expression optional

### DIFF
--- a/acir/src/native_types/expression/operators.rs
+++ b/acir/src/native_types/expression/operators.rs
@@ -140,16 +140,16 @@ impl Sub<&Expression> for &Expression {
 }
 
 impl Mul<&Expression> for &Expression {
-    type Output = Expression;
-    fn mul(self, rhs: &Expression) -> Expression {
+    type Output = Option<Expression>;
+    fn mul(self, rhs: &Expression) -> Option<Expression> {
         if self.is_const() {
-            return self.q_c * rhs;
+            return Some(self.q_c * rhs);
         } else if rhs.is_const() {
-            return self * rhs.q_c;
+            return Some(self * rhs.q_c);
         } else if !(self.is_linear() && rhs.is_linear()) {
             // `Expression`s can only represent terms which are up to degree 2.
             // We then disallow multiplication of `Expression`s which have degree 2 terms.
-            unreachable!("Can only multiply linear terms");
+            return None;
         }
 
         let mut output = Expression::from_field(self.q_c * rhs.q_c);
@@ -210,7 +210,7 @@ impl Mul<&Expression> for &Expression {
             i2 += 1;
         }
 
-        output
+        Some(output)
     }
 }
 
@@ -274,7 +274,7 @@ fn mul_smoketest() {
     };
 
     assert_eq!(
-        &a * &b,
+        (&a * &b).unwrap(),
         Expression {
             mul_terms: vec![(FieldElement::from(8u128), Witness(2), Witness(4)),],
             linear_combinations: vec![

--- a/acir/src/native_types/witness.rs
+++ b/acir/src/native_types/witness.rs
@@ -1,4 +1,9 @@
+use std::ops::Add;
+
+use acir_field::FieldElement;
 use serde::{Deserialize, Serialize};
+
+use super::Expression;
 
 // Witness might be a misnomer. This is an index that represents the position a witness will take
 #[derive(
@@ -26,5 +31,13 @@ impl Witness {
 impl From<u32> for Witness {
     fn from(value: u32) -> Self {
         Self(value)
+    }
+}
+
+impl Add<Witness> for Witness {
+    type Output = Expression;
+
+    fn add(self, rhs: Witness) -> Self::Output {
+        Expression::from(self).add_mul(FieldElement::one(), &Expression::from(rhs))
     }
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves https://github.com/noir-lang/acvm/issues/321

Resolves https://github.com/noir-lang/acvm/issues/335

## Summary\*

implement add trait for witness

make output of mul expression optional

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
