### PR TITLE
fix(acir)!: revert changes to `SchnorrVerify` opcode

### DIFF
--- a/acir/src/circuit/black_box_functions.rs
+++ b/acir/src/circuit/black_box_functions.rs
@@ -22,7 +22,12 @@ pub enum BlackBoxFunc {
     SHA256,
     /// Calculates the Blake2s hash of the inputs.
     Blake2s,
-    /// Verifies a Schnorr signature over the embedded curve.
+    /// Verifies a Schnorr signature over a curve which is "pairing friendly" with the curve on which the ACIR circuit is defined.
+    ///
+    /// The exact curve which this signature uses will vary based on the curve being used by ACIR.
+    /// For example, the BN254 curve supports Schnorr signatures over the [Grumpkin][grumpkin] curve.
+    ///
+    /// [grumpkin]: https://hackmd.io/@aztec-network/ByzgNxBfd#2-Grumpkin---A-curve-on-top-of-BN-254-for-SNARK-efficient-group-operations
     SchnorrVerify,
     /// Calculates a Pedersen commitment to the inputs.
     Pedersen,

--- a/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -42,8 +42,7 @@ pub enum BlackBoxFuncCall {
     SchnorrVerify {
         public_key_x: FunctionInput,
         public_key_y: FunctionInput,
-        signature_s: FunctionInput,
-        signature_e: FunctionInput,
+        signature: Vec<FunctionInput>,
         message: Vec<FunctionInput>,
         output: Witness,
     },
@@ -126,8 +125,7 @@ impl BlackBoxFuncCall {
             BlackBoxFunc::SchnorrVerify => BlackBoxFuncCall::SchnorrVerify {
                 public_key_x: FunctionInput::dummy(),
                 public_key_y: FunctionInput::dummy(),
-                signature_s: FunctionInput::dummy(),
-                signature_e: FunctionInput::dummy(),
+                signature: vec![],
                 message: vec![],
                 output: Witness(0),
             },
@@ -201,16 +199,14 @@ impl BlackBoxFuncCall {
             BlackBoxFuncCall::SchnorrVerify {
                 public_key_x,
                 public_key_y,
-                signature_s,
-                signature_e,
+                signature,
                 message,
                 ..
             } => {
-                let mut inputs = Vec::with_capacity(4 + message.len());
+                let mut inputs = Vec::with_capacity(2 + signature.len() + message.len());
                 inputs.push(*public_key_x);
                 inputs.push(*public_key_y);
-                inputs.push(*signature_s);
-                inputs.push(*signature_e);
+                inputs.extend(signature.iter().copied());
                 inputs.extend(message.iter().copied());
                 inputs
             }

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -76,8 +76,7 @@ pub trait BlackBoxFunctionSolver {
         &self,
         public_key_x: &FieldElement,
         public_key_y: &FieldElement,
-        signature_s: &FieldElement,
-        signature_e: &FieldElement,
+        signature: &[u8],
         message: &[u8],
     ) -> Result<bool, OpcodeResolutionError>;
     fn pedersen(

--- a/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm/src/pwg/blackbox/mod.rs
@@ -101,8 +101,7 @@ pub(crate) fn solve(
         BlackBoxFuncCall::SchnorrVerify {
             public_key_x,
             public_key_y,
-            signature_s,
-            signature_e,
+            signature,
             message,
             output,
         } => schnorr_verify(
@@ -110,8 +109,7 @@ pub(crate) fn solve(
             initial_witness,
             *public_key_x,
             *public_key_y,
-            *signature_s,
-            *signature_e,
+            signature,
             message,
             *output,
         ),

--- a/acvm/src/pwg/blackbox/signature/schnorr.rs
+++ b/acvm/src/pwg/blackbox/signature/schnorr.rs
@@ -17,21 +17,19 @@ pub(crate) fn schnorr_verify(
     initial_witness: &mut WitnessMap,
     public_key_x: FunctionInput,
     public_key_y: FunctionInput,
-    signature_s: FunctionInput,
-    signature_e: FunctionInput,
+    signature: &[FunctionInput],
     message: &[FunctionInput],
     output: Witness,
 ) -> Result<OpcodeResolution, OpcodeResolutionError> {
     let public_key_x: &FieldElement = witness_to_value(initial_witness, public_key_x.witness)?;
     let public_key_y: &FieldElement = witness_to_value(initial_witness, public_key_y.witness)?;
 
-    let signature_s: &FieldElement = witness_to_value(initial_witness, signature_s.witness)?;
-    let signature_e: &FieldElement = witness_to_value(initial_witness, signature_e.witness)?;
+    let signature = to_u8_vec(initial_witness, signature)?;
 
     let message = to_u8_vec(initial_witness, message)?;
 
     let valid_signature =
-        backend.schnorr_verify(public_key_x, public_key_y, signature_s, signature_e, &message)?;
+        backend.schnorr_verify(public_key_x, public_key_y, &signature, &message)?;
 
     insert_value(&output, FieldElement::from(valid_signature), initial_witness)?;
 

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -23,8 +23,7 @@ impl BlackBoxFunctionSolver for StubbedBackend {
         &self,
         _public_key_x: &FieldElement,
         _public_key_y: &FieldElement,
-        _signature_s: &FieldElement,
-        _signature_e: &FieldElement,
+        _signature: &[u8],
         _message: &[u8],
     ) -> Result<bool, OpcodeResolutionError> {
         panic!("Path not trodden by this test")

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
         "endianness",
         "euclidian",
         "funcs",
+        "grumpkin",
         "hasher",
         "keccak",
         "Merkle",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*



## Summary\*

This PR reverts the changes to the `SchnorrVerify` opcode made in https://github.com/noir-lang/acvm/pull/386. I've also defined this opcode more clearly.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
