### PR TITLE
feat(acvm)!: replace `PartialWitnessGeneratorStatus` with `ACVMStatus`

### DIFF
--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -149,7 +149,7 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
 
     /// Finalize the ACVM execution, returning the resulting [`WitnessMap`].
     pub fn finalize(self) -> WitnessMap {
-        if !matches!(self.status, ACVMStatus::Solved) {
+        if self.status != ACVMStatus::Solved {
             panic!("ACVM is not ready to be finalized");
         }
         self.witness_map

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -141,7 +141,7 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
         status
     }
 
-    /// Sets the VM status to [ACVMStatus::Failure] using the provided error`.
+    /// Sets the VM status to [ACVMStatus::Failure] using the provided `error`.
     /// Returns the new status.
     fn fail(&mut self, error: OpcodeResolutionError) -> ACVMStatus {
         self.status(ACVMStatus::Failure(error))

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -29,10 +29,17 @@ mod block;
 
 pub use brillig::ForeignCallWaitInfo;
 
-#[derive(Debug, PartialEq)]
-pub enum PartialWitnessGeneratorStatus {
+#[derive(Debug, Clone, PartialEq)]
+pub enum ACVMStatus {
     /// All opcodes have been solved.
     Solved,
+
+    /// The ACVM is in the process of executing the circuit.
+    InProgress,
+
+    /// The ACVM has encountered an irrecoverable error while executing the circuit and can not progress.
+    /// Most commonly this will be due to an unsatisfied constraint due to invalid inputs to the circuit.
+    Failure(OpcodeResolutionError),
 
     /// The ACVM has encountered a request for a Brillig [foreign call][acir::brillig_vm::Opcode::ForeignCall]
     /// to retrieve information from outside of the ACVM. The result of the foreign call must be passed back
@@ -62,7 +69,7 @@ pub enum OpcodeResolution {
 // TODO: ExpressionHasTooManyUnknowns is specific for arithmetic expressions
 // TODO: we could have a error enum for arithmetic failure cases in that module
 // TODO that can be converted into an OpcodeNotSolvable or OpcodeResolutionError enum
-#[derive(PartialEq, Eq, Debug, Error)]
+#[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum OpcodeNotSolvable {
     #[error("missing assignment for witness index {0}")]
     MissingAssignment(u32),
@@ -70,7 +77,7 @@ pub enum OpcodeNotSolvable {
     ExpressionHasTooManyUnknowns(Expression),
 }
 
-#[derive(PartialEq, Eq, Debug, Error)]
+#[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum OpcodeResolutionError {
     #[error("cannot solve opcode: {0}")]
     OpcodeNotSolvable(#[from] OpcodeNotSolvable),
@@ -85,6 +92,8 @@ pub enum OpcodeResolutionError {
 }
 
 pub struct ACVM<B: BlackBoxFunctionSolver> {
+    status: ACVMStatus,
+
     backend: B,
     /// Stores the solver for each [block][`Opcode::Block`] opcode. This persists their internal state to prevent recomputation.
     block_solvers: HashMap<BlockId, BlockSolver>,
@@ -102,6 +111,7 @@ pub struct ACVM<B: BlackBoxFunctionSolver> {
 impl<B: BlackBoxFunctionSolver> ACVM<B> {
     pub fn new(backend: B, opcodes: Vec<Opcode>, initial_witness: WitnessMap) -> Self {
         ACVM {
+            status: ACVMStatus::InProgress,
             backend,
             block_solvers: HashMap::default(),
             opcodes,
@@ -124,9 +134,22 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
         &self.opcodes
     }
 
+    /// Updates the current status of the VM.
+    /// Returns the given status.
+    fn status(&mut self, status: ACVMStatus) -> ACVMStatus {
+        self.status = status.clone();
+        status
+    }
+
+    /// Sets the VM status to [ACVMStatus::Failure] using the provided error`.
+    /// Returns the new status.
+    fn fail(&mut self, error: OpcodeResolutionError) -> ACVMStatus {
+        self.status(ACVMStatus::Failure(error))
+    }
+
     /// Finalize the ACVM execution, returning the resulting [`WitnessMap`].
     pub fn finalize(self) -> WitnessMap {
-        if self.opcodes.is_empty() || self.get_pending_foreign_call().is_some() {
+        if !matches!(self.status, ACVMStatus::Solved) {
             panic!("ACVM is not ready to be finalized");
         }
         self.witness_map
@@ -153,7 +176,7 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
     /// 1. All opcodes have been executed successfully.
     /// 2. The circuit has been found to be unsatisfiable.
     /// 2. A Brillig [foreign call][`UnresolvedBrilligCall`] has been encountered and must be resolved.
-    pub fn solve(&mut self) -> Result<PartialWitnessGeneratorStatus, OpcodeResolutionError> {
+    pub fn solve(&mut self) -> ACVMStatus {
         // TODO: Prevent execution with outstanding foreign calls?
         let mut unresolved_opcodes: Vec<Opcode> = Vec::new();
         while !self.opcodes.is_empty() {
@@ -212,7 +235,7 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
                     Err(OpcodeResolutionError::OpcodeNotSolvable(_)) => {
                         unreachable!("ICE - Result should have been converted to GateResolution")
                     }
-                    Err(err) => return Err(err),
+                    Err(error) => return self.fail(error),
                 }
             }
 
@@ -221,18 +244,19 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
 
             // We have oracles that must be externally resolved
             if self.get_pending_foreign_call().is_some() {
-                return Ok(PartialWitnessGeneratorStatus::RequiresForeignCall);
+                return self.status(ACVMStatus::RequiresForeignCall);
             }
 
             // We are stalled because of an opcode being bad
             if stalled && !self.opcodes.is_empty() {
-                return Err(OpcodeResolutionError::OpcodeNotSolvable(
+                let error = OpcodeResolutionError::OpcodeNotSolvable(
                     opcode_not_solvable
                         .expect("infallible: cannot be stalled and None at the same time"),
-                ));
+                );
+                return self.fail(error);
             }
         }
-        Ok(PartialWitnessGeneratorStatus::Solved)
+        self.status(ACVMStatus::Solved)
     }
 }
 

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -148,6 +148,9 @@ fn inversion_brillig_oracle_equivalence() {
     // After filling data request, continue solving
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+
+    // ACVM should be finalizable in `Solved` state.
+    acvm.finalize();
 }
 
 #[test]
@@ -294,6 +297,9 @@ fn double_inversion_brillig_oracle() {
     // After filling data request, continue solving
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+
+    // ACVM should be finalizable in `Solved` state.
+    acvm.finalize();
 }
 
 #[test]
@@ -423,6 +429,9 @@ fn oracle_dependent_execution() {
     // After filling data request, continue solving
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+
+    // ACVM should be finalizable in `Solved` state.
+    acvm.finalize();
 }
 
 #[test]
@@ -506,4 +515,7 @@ fn brillig_oracle_predicate() {
     let mut acvm = ACVM::new(StubbedBackend, opcodes, witness_assignments);
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
+
+    // ACVM should be finalizable in `Solved` state.
+    acvm.finalize();
 }

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -12,7 +12,7 @@ use acir::{
 };
 
 use acvm::{
-    pwg::{ForeignCallWaitInfo, OpcodeResolutionError, PartialWitnessGeneratorStatus, ACVM},
+    pwg::{ACVMStatus, ForeignCallWaitInfo, OpcodeResolutionError, ACVM},
     BlackBoxFunctionSolver,
 };
 
@@ -127,12 +127,12 @@ fn inversion_brillig_oracle_equivalence() {
 
     let mut acvm = ACVM::new(StubbedBackend, opcodes, witness_assignments);
     // use the partial witness generation solver with our acir program
-    let solver_status = acvm.solve().expect("should stall on brillig call");
+    let solver_status = acvm.solve();
 
     assert_eq!(
         solver_status,
-        PartialWitnessGeneratorStatus::RequiresForeignCall,
-        "Should require oracle data"
+        ACVMStatus::RequiresForeignCall,
+        "should require foreign call response"
     );
     assert!(acvm.unresolved_opcodes().is_empty(), "brillig should have been removed");
 
@@ -146,8 +146,8 @@ fn inversion_brillig_oracle_equivalence() {
     acvm.resolve_pending_foreign_call(foreign_call_result.into());
 
     // After filling data request, continue solving
-    let solver_status = acvm.solve().expect("should not stall on brillig call");
-    assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
+    let solver_status = acvm.solve();
+    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 }
 
 #[test]
@@ -255,11 +255,11 @@ fn double_inversion_brillig_oracle() {
     let mut acvm = ACVM::new(StubbedBackend, opcodes, witness_assignments);
 
     // use the partial witness generation solver with our acir program
-    let solver_status = acvm.solve().expect("should stall on oracle");
+    let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        PartialWitnessGeneratorStatus::RequiresForeignCall,
-        "Should require oracle data"
+        ACVMStatus::RequiresForeignCall,
+        "should require foreign call response"
     );
     assert!(acvm.unresolved_opcodes().is_empty(), "brillig should have been removed");
 
@@ -273,11 +273,11 @@ fn double_inversion_brillig_oracle() {
     acvm.resolve_pending_foreign_call(x_plus_y_inverse.into());
 
     // After filling data request, continue solving
-    let solver_status = acvm.solve().expect("should stall on brillig call");
+    let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        PartialWitnessGeneratorStatus::RequiresForeignCall,
-        "Should require oracle data"
+        ACVMStatus::RequiresForeignCall,
+        "should require foreign call response"
     );
     assert!(acvm.unresolved_opcodes().is_empty(), "should be fully solved");
 
@@ -292,8 +292,8 @@ fn double_inversion_brillig_oracle() {
     acvm.resolve_pending_foreign_call(i_plus_j_inverse.into());
 
     // After filling data request, continue solving
-    let solver_status = acvm.solve().expect("should not stall on brillig call");
-    assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
+    let solver_status = acvm.solve();
+    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 }
 
 #[test]
@@ -375,11 +375,11 @@ fn oracle_dependent_execution() {
     let mut acvm = ACVM::new(StubbedBackend, opcodes, witness_assignments);
 
     // use the partial witness generation solver with our acir program
-    let solver_status = acvm.solve().expect("should stall on oracle");
+    let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        PartialWitnessGeneratorStatus::RequiresForeignCall,
-        "Should require oracle data"
+        ACVMStatus::RequiresForeignCall,
+        "should require foreign call response"
     );
     assert_eq!(acvm.unresolved_opcodes().len(), 1, "brillig should have been removed");
     assert_eq!(
@@ -397,11 +397,11 @@ fn oracle_dependent_execution() {
     acvm.resolve_pending_foreign_call(x_inverse.into());
 
     // After filling data request, continue solving
-    let solver_status = acvm.solve().expect("should stall on oracle");
+    let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        PartialWitnessGeneratorStatus::RequiresForeignCall,
-        "Should require oracle data"
+        ACVMStatus::RequiresForeignCall,
+        "should require foreign call response"
     );
     assert_eq!(acvm.unresolved_opcodes().len(), 1, "brillig should have been removed");
     assert_eq!(
@@ -421,8 +421,8 @@ fn oracle_dependent_execution() {
     // We've resolved all the brillig foreign calls so we should be able to complete execution now.
 
     // After filling data request, continue solving
-    let solver_status = acvm.solve().expect("should not stall on brillig call");
-    assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
+    let solver_status = acvm.solve();
+    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 }
 
 #[test]
@@ -504,6 +504,6 @@ fn brillig_oracle_predicate() {
     .into();
 
     let mut acvm = ACVM::new(StubbedBackend, opcodes, witness_assignments);
-    let solver_status = acvm.solve().expect("should not stall on brillig call");
-    assert_eq!(solver_status, PartialWitnessGeneratorStatus::Solved, "should be fully solved");
+    let solver_status = acvm.solve();
+    assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 }

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -149,7 +149,7 @@ fn inversion_brillig_oracle_equivalence() {
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 
-    // ACVM should be finalizable in `Solved` state.
+    // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
 }
 
@@ -298,7 +298,7 @@ fn double_inversion_brillig_oracle() {
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 
-    // ACVM should be finalizable in `Solved` state.
+    // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
 }
 
@@ -430,7 +430,7 @@ fn oracle_dependent_execution() {
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 
-    // ACVM should be finalizable in `Solved` state.
+    // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
 }
 
@@ -516,6 +516,6 @@ fn brillig_oracle_predicate() {
     let solver_status = acvm.solve();
     assert_eq!(solver_status, ACVMStatus::Solved, "should be fully solved");
 
-    // ACVM should be finalizable in `Solved` state.
+    // ACVM should be able to be finalized in `Solved` state.
     acvm.finalize();
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR pulls the `ACVMStatus` enum from #399 so that it can be merged separately from the simplifications to the rest of the ACVM.

Also fixes an issue where the ACVM could not be finalised when fully solved.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
