### PR TITLE
fix: maintain `Opcode` ordering in `CSATTransformer`

### DIFF
--- a/acir/src/native_types/expression/ordering.rs
+++ b/acir/src/native_types/expression/ordering.rs
@@ -4,7 +4,7 @@ use std::cmp::Ordering;
 use super::Expression;
 
 // TODO: It's undecided whether `Expression` should implement `Ord/PartialOrd`.
-// This is currently used in ACVM in the compiler.
+// This is not currently used in ACVM.
 
 impl Ord for Expression {
     fn cmp(&self, other: &Self) -> Ordering {

--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -102,7 +102,6 @@ pub fn compile(
                     new_gates.push(intermediate_gate);
                 }
                 new_gates.push(arith_expr);
-                new_gates.sort();
                 for gate in new_gates {
                     new_opcode_labels.push(opcode_label[index]);
                     transformed_gates.push(Opcode::Arithmetic(gate));


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR stops us from sorting the set of arithmetic opcodes produced by the `CSATTransformer`. 

Consider the arithmetic opcode
```
EXPR [ (1, _1, _7) (1, _5, _8) (-1, _1) (-1, _9) -1 ]
```

This currently gets transformed into

```
EXPR [ (1, _1, _7) (-1, _13) 0 ]
EXPR [ (1, _5, _8) (-1, _14) 0 ]
EXPR [ (-1, _1) (-1, _9) (1, _15) -1 ]
EXPR [ (1, _13) (1, _14) (-1, _15) 0 ]
```

The 3rd and 4th opcodes have been swapped as the original opcode's linear term gets it sorted before the final intermediate value gate. If we don't sort the gates then we get the result

```
EXPR [ (1, _1, _7) (-1, _13) 0 ]
EXPR [ (1, _5, _8) (-1, _14) 0 ]
EXPR [ (1, _13) (1, _14) (-1, _15) 0 ]
EXPR [ (-1, _1) (-1, _9) (1, _15) -1 ]
```

This is what we expect as the gate which pulls together all of the intermediate values is at the end so can act once these are set.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
