### PR TITLE
feat(acvm)!: Add `circuit: &Circuit` to `eth_contract_from_vk` function signature

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -100,8 +100,8 @@ pub trait SmartContract {
     fn eth_contract_from_vk(
         &self,
         common_reference_string: &[u8],
-        verification_key: &[u8],
         circuit: &Circuit,
+        verification_key: &[u8],
     ) -> Result<String, Self::Error>;
 }
 

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -101,6 +101,7 @@ pub trait SmartContract {
         &self,
         common_reference_string: &[u8],
         verification_key: &[u8],
+        circuit: &Circuit,
     ) -> Result<String, Self::Error>;
 }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

Adds `circuit: &Circuit` to the `eth_contract_from_vk` function signature in the `SmartContract` trait for ACVM backends

## Problem\*

Halo2 Backend needs to know the number of public inputs to generate the smart contract verifier for proofs. With the ACVM backend API, there is currently no way to pass this value into `eth_contract_from_vk`.

Resolves: https://github.com/noir-lang/acvm/issues/411

## Summary\*

Minimal changes- see description

Will require that `acvm-backend-barretenberg` passes in the ACIR even though it doesn't need it:
https://github.com/noir-lang/acvm-backend-barretenberg/blob/master/src/acvm_interop/smart_contract.rs#L12-L16

And that `nargo` supplies the ACIR when calling `eth_contract_from_vk` from the backend:
https://github.com/noir-lang/noir/blob/master/crates/nargo/src/ops/codegen_verifier.rs#L3-L9
## Additional Context

NA

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
