### PR TITLE
feat: derive PartialOrd, Ord, and Hash on RegisterIndex

### DIFF
--- a/brillig/src/opcodes.rs
+++ b/brillig/src/opcodes.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 pub type Label = usize;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct RegisterIndex(pub usize);
 
 /// `RegisterIndex` refers to the index in VM register space.


### PR DESCRIPTION
# Description

## Problem\*

I want to be able to use register indices however I may need in the code gen implementation of brillig. In this instance register indices are going to be used in a map to associate slices to their size at runtime.  

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [X] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
