### PR TITLE
chore: remove unnecessary workspace dependencies

### DIFF
--- a/blackbox_solver/Cargo.toml
+++ b/blackbox_solver/Cargo.toml
@@ -11,7 +11,6 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acir_field.workspace = true
 acir.workspace = true
 thiserror.workspace = true
 
@@ -35,5 +34,5 @@ p256 = { version = "0.11.0", features = [
 
 [features]
 default = ["bn254"]
-bn254 = ["acir_field/bn254"]
-bls12_381 = ["acir_field/bls12_381"]
+bn254 = ["acir/bn254"]
+bls12_381 = ["acir/bls12_381"]

--- a/blackbox_solver/src/lib.rs
+++ b/blackbox_solver/src/lib.rs
@@ -5,8 +5,7 @@
 //! For functions that are backend-dependent, it provides a Trait [BlackBoxFunctionSolver] that must be implemented by the backend.
 //! For functions that have a reference implementation, such as [keccak256], this crate exports the reference implementation directly.
 
-use acir::BlackBoxFunc;
-use acir_field::FieldElement;
+use acir::{BlackBoxFunc, FieldElement};
 use blake2::digest::generic_array::GenericArray;
 use blake2::{Blake2s256, Digest};
 use sha2::Sha256;

--- a/brillig_vm/Cargo.toml
+++ b/brillig_vm/Cargo.toml
@@ -11,12 +11,10 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-acir_field.workspace = true
 acir.workspace = true
-brillig.workspace = true
 blackbox_solver.workspace = true
 
 [features]
 default = ["bn254"]
-bn254 = ["acir_field/bn254", "acir/bn254", "brillig/bn254"]
-bls12_381 = ["acir_field/bls12_381", "acir/bls12_381", "brillig/bls12_381"]
+bn254 = ["acir/bn254"]
+bls12_381 = ["acir/bls12_381"]

--- a/brillig_vm/src/arithmetic.rs
+++ b/brillig_vm/src/arithmetic.rs
@@ -1,5 +1,5 @@
-use acir_field::FieldElement;
-use brillig::{BinaryFieldOp, BinaryIntOp};
+use acir::brillig::{BinaryFieldOp, BinaryIntOp};
+use acir::FieldElement;
 
 /// Evaluate a binary operation on two FieldElements and return the result as a FieldElement.
 pub(crate) fn evaluate_binary_field_op(

--- a/brillig_vm/src/black_box.rs
+++ b/brillig_vm/src/black_box.rs
@@ -1,10 +1,9 @@
-use acir::BlackBoxFunc;
-use acir_field::FieldElement;
+use acir::brillig::{BlackBoxOp, HeapArray, HeapVector, Value};
+use acir::{BlackBoxFunc, FieldElement};
 use blackbox_solver::{
     blake2s, ecdsa_secp256k1_verify, ecdsa_secp256r1_verify, hash_to_field_128_security, keccak256,
     sha256, BlackBoxFunctionSolver, BlackBoxResolutionError,
 };
-use brillig::{BlackBoxOp, HeapArray, HeapVector, Value};
 
 use crate::{Memory, Registers};
 
@@ -166,7 +165,7 @@ pub(crate) fn evaluate_black_box<Solver: BlackBoxFunctionSolver>(
 
 #[cfg(test)]
 mod test {
-    use brillig::BlackBoxOp;
+    use acir::brillig::BlackBoxOp;
 
     use crate::{
         black_box::{evaluate_black_box, to_u8_vec, to_value_vec},

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -9,21 +9,23 @@
 //! [acir]: https://crates.io/crates/acir
 //! [acvm]: https://crates.io/crates/acvm
 
+use acir::brillig::{
+    BinaryFieldOp, BinaryIntOp, ForeignCallOutput, ForeignCallResult, HeapArray, HeapVector,
+    Opcode, RegisterIndex, RegisterOrMemory, Value,
+};
+use acir::FieldElement;
+// Re-export `brillig`.
+pub use acir::brillig;
+
 mod arithmetic;
 mod black_box;
 mod memory;
 mod registers;
 
-use acir_field::FieldElement;
 use arithmetic::{evaluate_binary_field_op, evaluate_binary_int_op};
 use black_box::evaluate_black_box;
 use blackbox_solver::{BlackBoxFunctionSolver, BlackBoxResolutionError};
-use brillig::{
-    BinaryFieldOp, BinaryIntOp, ForeignCallOutput, ForeignCallResult, HeapArray, HeapVector,
-    Opcode, RegisterIndex, RegisterOrMemory, Value,
-};
 
-pub use brillig;
 pub use memory::Memory;
 pub use registers::Registers;
 

--- a/brillig_vm/src/registers.rs
+++ b/brillig_vm/src/registers.rs
@@ -1,4 +1,4 @@
-use brillig::{RegisterIndex, Value};
+use acir::brillig::{RegisterIndex, Value};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Registers {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

The `acir` crate reexports the `acir_field` and `brillig` crates so I've simplified any consumers of these to use the versions from `acir`.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
