### PR TITLE
feat(acvm): reexport `blackbox_solver` crate from `acvm`

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -20,6 +20,8 @@ pub use acir;
 pub use acir::FieldElement;
 // re-export brillig vm
 pub use brillig_vm;
+// re-export blackbox solver
+pub use blackbox_solver;
 
 /// Supported NP complete languages
 /// This might need to be in ACIR instead


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves #300 
Resolves #372 

## Summary\*

This PR adds a re-export for the `blackbox_solver` crate so that consumers of the ACVM can execute the blackbox opcodes externally.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
