### PR TITLE
fix: Remove panic when we divide 0/0 in quotient directive

### DIFF
--- a/acvm/src/pwg/directives/mod.rs
+++ b/acvm/src/pwg/directives/mod.rs
@@ -188,3 +188,31 @@ fn format_field_string(field: FieldElement) -> String {
     }
     "0x".to_owned() + &trimmed_field
 }
+
+#[cfg(test)]
+mod tests {
+    use acir::{
+        circuit::directives::{Directive, QuotientDirective},
+        native_types::{Expression, Witness, WitnessMap},
+        FieldElement,
+    };
+
+    use super::solve_directives_internal;
+
+    #[test]
+    fn divisor_is_zero() {
+        let quotient_directive = QuotientDirective {
+            a: Expression::zero(),
+            b: Expression::zero(),
+            q: Witness(0),
+            r: Witness(0),
+            predicate: Some(Expression::one()),
+        };
+
+        let mut witness_map = WitnessMap::new();
+        witness_map.insert(Witness(0), FieldElement::zero());
+
+        solve_directives_internal(&mut witness_map, &Directive::Quotient(quotient_directive))
+            .expect("expected 0/0 to return 0");
+    }
+}

--- a/acvm/src/pwg/directives/mod.rs
+++ b/acvm/src/pwg/directives/mod.rs
@@ -58,7 +58,7 @@ fn solve_directives_internal(
                 None => FieldElement::one(),
             };
 
-            let (int_r, int_q) = if pred_value.is_zero() {
+            let (int_r, int_q) = if pred_value.is_zero() || int_b.is_zero() {
                 (BigUint::zero(), BigUint::zero())
             } else {
                 (&int_a % &int_b, &int_a / &int_b)


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

A directive should ideally not panic when we are dividing zero by zero. The input is not trusted and should be constrained, so it is okay to return 0 when we have 0/0.

Related: https://github.com/noir-lang/noir/issues/1802

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
