### PR TITLE
chore: remove unused dev dependencies

### DIFF
--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -44,5 +44,3 @@ unstable-fallbacks = []
 [dev-dependencies]
 rand = "0.8.5"
 proptest = "1.2.0"
-blake2 = "0.10.6"
-sha2 = "0.10.6"

--- a/acvm/src/pwg/directives/sorting.rs
+++ b/acvm/src/pwg/directives/sorting.rs
@@ -245,9 +245,11 @@ pub(super) fn route(inputs: Vec<FieldElement>, outputs: Vec<FieldElement>) -> Ve
 
 #[cfg(test)]
 mod tests {
+    // Silence `unused_crate_dependencies` warning
+    use proptest as _;
+
     use super::route;
     use acir::FieldElement;
-    use proptest as _;
     use rand::prelude::*;
 
     fn execute_network(config: Vec<bool>, inputs: Vec<FieldElement>) -> Vec<FieldElement> {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This addresses some warnings about unused dev dependencies in the `acvm` crate.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
