### PR TITLE
feat: add optimisations to fallback black box functions on booleans

### DIFF
--- a/stdlib/src/blackbox_fallbacks/logic_fallbacks.rs
+++ b/stdlib/src/blackbox_fallbacks/logic_fallbacks.rs
@@ -19,6 +19,9 @@ pub fn range(gate: Expression, bit_size: u32, mut num_witness: u32) -> (u32, Vec
     (updated_witness_counter, new_gates)
 }
 
+/// Returns a set of opcodes which constrain `a & b == result`
+///
+/// `a` and `b` are assumed to be constrained to fit within `bit_size` externally.
 pub fn and(
     a: Expression,
     b: Expression,
@@ -69,6 +72,9 @@ pub fn and(
     (updated_witness_counter, new_gates)
 }
 
+/// Returns a set of opcodes which constrain `a ^ b == result`
+///
+/// `a` and `b` are assumed to be constrained to fit within `bit_size` externally.
 pub fn xor(
     a: Expression,
     b: Expression,


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR adds special cases to the fallback implementations of logic black box functions. This removes unnecessary an unnecessary `toLeRadix` directive and the resulting dummy witness which just gets constrained to be equal to an existing witness.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
