### PR TITLE
chore: Improve readability of `BlockSolver.solve_memory_op`

### DIFF
--- a/acir/src/circuit/opcodes/block.rs
+++ b/acir/src/circuit/opcodes/block.rs
@@ -1,4 +1,4 @@
-use crate::native_types::Expression;
+use crate::native_types::{Expression, Witness};
 use acir_field::FieldElement;
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +13,19 @@ pub struct MemOp {
     pub operation: Expression,
     pub index: Expression,
     pub value: Expression,
+}
+
+impl MemOp {
+    /// Creates a `MemOp` which reads from memory at `index` and inserts the read value
+    /// into the [`WitnessMap`][crate::native_types::WitnessMap] at `witness`
+    pub fn read_at_mem_index(index: Expression, witness: Witness) -> Self {
+        MemOp { operation: Expression::zero(), index, value: witness.into() }
+    }
+
+    /// Creates a `MemOp` which writes the [`Expression`] `value` into memory at `index`.
+    pub fn write_to_mem_index(index: Expression, value: Expression) -> Self {
+        MemOp { operation: Expression::one(), index, value }
+    }
 }
 
 /// Represents operations on a block of length len of data

--- a/acvm/src/pwg/arithmetic.rs
+++ b/acvm/src/pwg/arithmetic.rs
@@ -235,21 +235,6 @@ impl ArithmeticSolver {
         result.q_c += expr.q_c;
         result
     }
-
-    // Returns one witness belonging to an expression, in no relevant order
-    // Returns None if the expression is const
-    // The function is used during partial witness generation to report unsolved witness
-    pub(super) fn any_witness_from_expression(expr: &Expression) -> Option<Witness> {
-        if expr.linear_combinations.is_empty() {
-            if expr.mul_terms.is_empty() {
-                None
-            } else {
-                Some(expr.mul_terms[0].1)
-            }
-        } else {
-            Some(expr.linear_combinations[0].1)
-        }
-    }
 }
 
 #[test]

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -75,7 +75,7 @@ impl BlockSolver {
             // into this value.
             let value_read_witness = value.to_witness().expect("This should be a witness");
 
-            let value_in_array = self.read_memory_index(memory_index)?;
+            let value_in_array = self.read_memory_index(memory_index);
 
             insert_value(&value_read_witness, value_in_array, initial_witness)
         } else {

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -6,11 +6,7 @@ use acir::{
     FieldElement,
 };
 
-use super::{
-    any_witness_from_expression,
-    arithmetic::{ArithmeticSolver, GateStatus},
-    get_value, insert_value,
-};
+use super::{any_witness_from_expression, arithmetic::ArithmeticSolver, get_value, insert_value};
 use super::{OpcodeNotSolvable, OpcodeResolution, OpcodeResolutionError};
 
 type MemoryIndex = u32;
@@ -95,7 +91,7 @@ impl BlockSolver {
             let value_in_array =
                 self.get_value(memory_index).ok_or_else(|| missing_assignment(Some(Witness(0))))?;
 
-            insert_value(&value_read_witness, value_in_array, initial_witness)?;
+            insert_value(&value_read_witness, value_in_array, initial_witness)
         } else {
             // arr[memory_index] = value_write
             //
@@ -106,8 +102,8 @@ impl BlockSolver {
             let value_to_write = get_value(&value_write, initial_witness).expect("Change");
 
             self.insert_value(memory_index, value_to_write);
+            Ok(())
         }
-        Ok(())
     }
 
     // Try to solve block operations from the trace

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -71,6 +71,9 @@ impl BlockSolver {
         let memory_index = index.try_to_u64().unwrap() as MemoryIndex;
 
         // Calculate the value associated with this memory operation.
+        //
+        // In read operations, this corresponds to the witness index at which the value from memory will be written.
+        // In write operations, this corresponds to the expression which will be written to memory.
         let value = ArithmeticSolver::evaluate(&op.value, initial_witness);
 
         // `operation == 0` implies a read operation. (`operation == 1` implies write operation).

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -93,7 +93,7 @@ impl BlockSolver {
             // into the memory block.
             let value_write = value;
 
-            let value_to_write = get_value(&value_write, initial_witness).expect("Change");
+            let value_to_write = get_value(&value_write, initial_witness)?;
 
             self.write_memory_index(memory_index, value_to_write);
             Ok(())

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -81,7 +81,9 @@ impl BlockSolver {
             //
             // This is the value that we want to read into; i.e. copy from the memory block
             // into this value.
-            let value_read_witness = value.to_witness().expect("This should be a witness");
+            let value_read_witness = value.to_witness().expect(
+                "Memory must be read into a specified witness index, encountered an Expression",
+            );
 
             let value_in_array = self.read_memory_index(memory_index);
 

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -144,14 +144,16 @@ mod tests {
             (Witness(3), FieldElement::from(2u128)),
         ]));
 
+        let init = vec![Witness(1), Witness(2)];
+
         let trace = vec![
-            MemOp::write_to_mem_index(FieldElement::from(0u128).into(), Witness(1).into()),
-            MemOp::write_to_mem_index(FieldElement::from(1u128).into(), Witness(2).into()),
             MemOp::write_to_mem_index(FieldElement::from(2u128).into(), Witness(3).into()),
             MemOp::read_at_mem_index(FieldElement::one().into(), Witness(4)),
         ];
 
         let mut block_solver = BlockSolver::default();
+        block_solver.init(&init, &initial_witness).unwrap();
+
         block_solver.solve(&mut initial_witness, &trace).unwrap();
         assert_eq!(initial_witness[&Witness(4)], FieldElement::one());
     }

--- a/acvm/src/pwg/block.rs
+++ b/acvm/src/pwg/block.rs
@@ -6,7 +6,7 @@ use acir::{
     FieldElement,
 };
 
-use super::{arithmetic::ArithmeticSolver, get_value, insert_value};
+use super::{arithmetic::ArithmeticSolver, get_value, insert_value, witness_to_value};
 use super::{OpcodeResolution, OpcodeResolutionError};
 
 type MemoryIndex = u32;
@@ -30,10 +30,18 @@ impl BlockSolver {
     }
 
     /// Set the block_value from a MemoryInit opcode
-    pub(crate) fn init(&mut self, init: &[Witness], initial_witness: &WitnessMap) {
-        for (i, w) in init.iter().enumerate() {
-            self.write_memory_index(i as u32, initial_witness[w]);
+    pub(crate) fn init(
+        &mut self,
+        init: &[Witness],
+        initial_witness: &WitnessMap,
+    ) -> Result<(), OpcodeResolutionError> {
+        for (memory_index, witness) in init.iter().enumerate() {
+            self.write_memory_index(
+                memory_index as MemoryIndex,
+                *witness_to_value(initial_witness, *witness)?,
+            );
         }
+        Ok(())
     }
 
     // Helper function which tries to solve a Block opcode

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -232,16 +232,13 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
                     }
                     Opcode::MemoryInit { block_id, init } => {
                         let solver = self.block_solvers.entry(*block_id).or_default();
-                        solver.init(init, &self.witness_map);
-                        Ok(OpcodeResolution::Solved)
+                        solver.init(init, &self.witness_map).map(|_| OpcodeResolution::Solved)
                     }
                     Opcode::MemoryOp { block_id, op } => {
                         let solver = self.block_solvers.entry(*block_id).or_default();
-                        let result = solver.solve_memory_op(op, &mut self.witness_map);
-                        match result {
-                            Ok(_) => Ok(OpcodeResolution::Solved),
-                            Err(err) => Err(err),
-                        }
+                        solver
+                            .solve_memory_op(op, &mut self.witness_map)
+                            .map(|_| OpcodeResolution::Solved)
                     }
                 };
 

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -347,11 +347,9 @@ pub fn get_value(
     let expr = ArithmeticSolver::evaluate(expr, initial_witness);
     match expr.to_const() {
         Some(value) => Ok(value),
-        None => {
-            Err(OpcodeResolutionError::OpcodeNotSolvable(OpcodeNotSolvable::MissingAssignment(
-                ArithmeticSolver::any_witness_from_expression(&expr).unwrap().0,
-            )))
-        }
+        None => Err(OpcodeResolutionError::OpcodeNotSolvable(
+            OpcodeNotSolvable::MissingAssignment(any_witness_from_expression(&expr).unwrap().0),
+        )),
     }
 }
 
@@ -378,6 +376,21 @@ pub fn insert_value(
     }
 
     Ok(())
+}
+
+// Returns one witness belonging to an expression, in no relevant order
+// Returns None if the expression is const
+// The function is used during partial witness generation to report unsolved witness
+fn any_witness_from_expression(expr: &Expression) -> Option<Witness> {
+    if expr.linear_combinations.is_empty() {
+        if expr.mul_terms.is_empty() {
+            None
+        } else {
+            Some(expr.mul_terms[0].1)
+        }
+    } else {
+        Some(expr.linear_combinations[0].1)
+    }
 }
 
 /// A Brillig VM process has requested the caller to solve a [foreign call][brillig_vm::Opcode::ForeignCall] externally


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR just does some code reorganisation and renaming of variables to make this function a little clearer.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
