### PR TITLE
chore: deprecate `BlackBoxFuncCall::dummy()`

### DIFF
--- a/acir/src/circuit/opcodes/black_box_function_call.rs
+++ b/acir/src/circuit/opcodes/black_box_function_call.rs
@@ -114,6 +114,7 @@ pub enum BlackBoxFuncCall {
 }
 
 impl BlackBoxFuncCall {
+    #[deprecated = "BlackBoxFuncCall::dummy() is unnecessary and will be removed in ACVM 0.24.0"]
     pub fn dummy(bb_func: BlackBoxFunc) -> Self {
         match bb_func {
             BlackBoxFunc::AND => BlackBoxFuncCall::AND {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This function is no longer used by Noir (and was basically a hack) so I've deprecated it for later removal.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
