### PR TITLE
chore: keep ACVM JS in sync with ACVM version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -37,7 +37,7 @@
           "type": "json",
           "path": "acvm_js/package.json",
           "jsonpath": "$.version"
-        }        
+        }
       ]
     },
     "acir": {
@@ -78,6 +78,7 @@
         "acir",
         "acir_field",
         "acvm",
+        "acvm_js",
         "brillig",
         "brillig_vm",
         "acvm_stdlib",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

ACVM JS needs to be placed into the same group of linked versions as the ACVM package.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
