### PR TITLE
fix: Divide field by zero

### DIFF
--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -374,9 +374,9 @@ impl<F: PrimeField> Mul for FieldElement<F> {
 }
 impl<F: PrimeField> Div for FieldElement<F> {
     type Output = FieldElement<F>;
-    #[allow(clippy::suspicious_arithmetic_impl)]
-    fn div(self, rhs: FieldElement<F>) -> Self::Output {
-        self * rhs.inverse()
+    fn div(mut self, rhs: FieldElement<F>) -> Self::Output {
+        self.0.div_assign(&rhs.0);
+        FieldElement(self.0)
     }
 }
 impl<F: PrimeField> Add for FieldElement<F> {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

I don't know if this will fully resolve the issue. if the issue persists, i'll also change the code here

https://github.com/noir-lang/noir/blob/master/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs#L367-L382
https://github.com/noir-lang/noir/blob/master/crates/noirc_evaluator/src/ssa/acir_gen/acir_ir/acir_variable.rs#L203-L231

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Related to https://github.com/noir-lang/noir/issues/2149

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
