### PR TITLE
feat!: Switched from OpcodeLabel to OpcodeLocation and ErrorLocation

### DIFF
--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -31,13 +31,12 @@ pub struct Circuit {
     pub return_values: PublicInputs,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
-/// Opcodes are given labels so that callers can
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+/// Opcodes are locatable so that callers can
 /// map opcodes to debug information related to their context.
-pub enum OpcodeLabel {
-    #[default]
-    Unresolved,
-    Resolved(u64),
+pub enum OpcodeLocation {
+    Acir(usize),
+    Brillig(usize, usize),
 }
 
 impl Circuit {
@@ -91,11 +90,6 @@ impl Circuit {
         gz_decoder.read_to_end(&mut buf_d).unwrap();
         let circuit = bincode::deserialize(&buf_d).unwrap();
         Ok(circuit)
-    }
-
-    /// Initial list of labels attached to opcodes.
-    pub fn initial_opcode_labels(&self) -> Vec<OpcodeLabel> {
-        (0..self.opcodes.len()).map(|label| OpcodeLabel::Resolved(label as u64)).collect()
     }
 }
 

--- a/acir/src/circuit/mod.rs
+++ b/acir/src/circuit/mod.rs
@@ -57,6 +57,8 @@ pub enum OpcodeLocationFromStrError {
     InvalidOpcodeLocationString(String),
 }
 
+/// The implementation of display and FromStr allows serializing and deserializing a OpcodeLocation to a string.
+/// This is useful when used as key in a map that has to be serialized to JSON/TOML, for example when mapping an opcode to its metadata.
 impl FromStr for OpcodeLocation {
     type Err = OpcodeLocationFromStrError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {

--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -28,6 +28,7 @@ pub enum CompileError {
 
 /// This module moves and decomposes acir opcodes. The transformation map allows consumers of this module to map
 /// metadata they had about the opcodes to the new opcode structure generated after the transformation.
+#[derive(Debug)]
 pub struct AcirTransformationMap {
     /// This is a vector of pointers to the old acir opcodes. The index of the vector is the new opcode index.
     /// The value of the vector is the old opcode index pointed.

--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -35,23 +35,21 @@ fn create_acir_transformation_map(
     let mut transformation_map = HashMap::new();
 
     for (new_index, original_index) in acir_opcode_positions.into_iter().enumerate() {
-        if original_index != new_index {
-            transformation_map
-                .insert(OpcodeLocation::Acir(original_index), OpcodeLocation::Acir(new_index));
-            let opcode = &acir.opcodes[new_index];
-            if let Opcode::Brillig(brillig) = opcode {
-                for (brillig_opcode_index, _) in brillig.bytecode.iter().enumerate() {
-                    transformation_map.insert(
-                        OpcodeLocation::Brillig {
-                            acir_index: original_index,
-                            brillig_index: brillig_opcode_index,
-                        },
-                        OpcodeLocation::Brillig {
-                            acir_index: new_index,
-                            brillig_index: brillig_opcode_index,
-                        },
-                    );
-                }
+        transformation_map
+            .insert(OpcodeLocation::Acir(new_index), OpcodeLocation::Acir(original_index));
+        let opcode = &acir.opcodes[new_index];
+        if let Opcode::Brillig(brillig) = opcode {
+            for (brillig_opcode_index, _) in brillig.bytecode.iter().enumerate() {
+                transformation_map.insert(
+                    OpcodeLocation::Brillig {
+                        acir_index: new_index,
+                        brillig_index: brillig_opcode_index,
+                    },
+                    OpcodeLocation::Brillig {
+                        acir_index: original_index,
+                        brillig_index: brillig_opcode_index,
+                    },
+                );
             }
         }
     }

--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -42,8 +42,14 @@ fn create_acir_transformation_map(
             if let Opcode::Brillig(brillig) = opcode {
                 for (brillig_opcode_index, _) in brillig.bytecode.iter().enumerate() {
                     transformation_map.insert(
-                        OpcodeLocation::Brillig(original_index, brillig_opcode_index),
-                        OpcodeLocation::Brillig(new_index, brillig_opcode_index),
+                        OpcodeLocation::Brillig {
+                            acir_index: original_index,
+                            brillig_index: brillig_opcode_index,
+                        },
+                        OpcodeLocation::Brillig {
+                            acir_index: new_index,
+                            brillig_index: brillig_opcode_index,
+                        },
                     );
                 }
             }

--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -34,7 +34,7 @@ fn create_acir_transformation_map(
 ) -> HashMap<OpcodeLocation, OpcodeLocation> {
     let mut transformation_map = HashMap::new();
 
-    for (original_index, new_index) in acir_opcode_positions.into_iter().enumerate() {
+    for (new_index, original_index) in acir_opcode_positions.into_iter().enumerate() {
         if original_index != new_index {
             transformation_map
                 .insert(OpcodeLocation::Acir(original_index), OpcodeLocation::Acir(new_index));

--- a/acvm/src/pwg/arithmetic.rs
+++ b/acvm/src/pwg/arithmetic.rs
@@ -1,10 +1,9 @@
 use acir::{
-    circuit::OpcodeLabel,
     native_types::{Expression, Witness, WitnessMap},
     FieldElement,
 };
 
-use super::{insert_value, OpcodeNotSolvable, OpcodeResolutionError};
+use super::{insert_value, ErrorLocation, OpcodeNotSolvable, OpcodeResolutionError};
 
 /// An Arithmetic solver will take a Circuit's arithmetic gates with witness assignments
 /// and create the other witness variables
@@ -48,7 +47,7 @@ impl ArithmeticSolver {
                     if (q + b).is_zero() {
                         if !total_sum.is_zero() {
                             Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                                opcode_label: OpcodeLabel::Unresolved,
+                                opcode_location: ErrorLocation::Unresolved,
                             })
                         } else {
                             Ok(())
@@ -75,7 +74,7 @@ impl ArithmeticSolver {
                 if partial_prod.is_zero() {
                     if !total_sum.is_zero() {
                         Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                            opcode_label: OpcodeLabel::Unresolved,
+                            opcode_location: ErrorLocation::Unresolved,
                         })
                     } else {
                         Ok(())
@@ -92,7 +91,7 @@ impl ArithmeticSolver {
                 // There is nothing to solve
                 if !(a + b + gate.q_c).is_zero() {
                     Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                        opcode_label: OpcodeLabel::Unresolved,
+                        opcode_location: ErrorLocation::Unresolved,
                     })
                 } else {
                     Ok(())
@@ -109,7 +108,7 @@ impl ArithmeticSolver {
                 if coeff.is_zero() {
                     if !total_sum.is_zero() {
                         Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                            opcode_label: OpcodeLabel::Unresolved,
+                            opcode_location: ErrorLocation::Unresolved,
                         })
                     } else {
                         Ok(())

--- a/acvm/src/pwg/blackbox/range.rs
+++ b/acvm/src/pwg/blackbox/range.rs
@@ -1,8 +1,8 @@
-use crate::{pwg::witness_to_value, OpcodeResolutionError};
-use acir::{
-    circuit::{opcodes::FunctionInput, OpcodeLabel},
-    native_types::WitnessMap,
+use crate::{
+    pwg::{witness_to_value, ErrorLocation},
+    OpcodeResolutionError,
 };
+use acir::{circuit::opcodes::FunctionInput, native_types::WitnessMap};
 
 pub(super) fn solve_range_opcode(
     initial_witness: &mut WitnessMap,
@@ -11,7 +11,7 @@ pub(super) fn solve_range_opcode(
     let w_value = witness_to_value(initial_witness, input.witness)?;
     if w_value.num_bits() > input.num_bits {
         return Err(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_label: OpcodeLabel::Unresolved,
+            opcode_location: ErrorLocation::Unresolved,
         });
     }
     Ok(())

--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -108,7 +108,7 @@ impl BrilligSolver {
             }
             VMStatus::InProgress => unreachable!("Brillig VM has not completed execution"),
             VMStatus::Failure { message } => {
-                Err(OpcodeResolutionError::BrilligFunctionFailed(message))
+                Err(OpcodeResolutionError::BrilligFunctionFailed(message, vm.program_counter()))
             }
             VMStatus::ForeignCallWait { function, inputs } => {
                 Ok(Some(ForeignCallWaitInfo { function, inputs }))

--- a/acvm/src/pwg/directives/mod.rs
+++ b/acvm/src/pwg/directives/mod.rs
@@ -1,10 +1,7 @@
 use std::cmp::Ordering;
 
 use acir::{
-    circuit::{
-        directives::{Directive, LogInfo, QuotientDirective},
-        OpcodeLabel,
-    },
+    circuit::directives::{Directive, LogInfo, QuotientDirective},
     native_types::WitnessMap,
     FieldElement,
 };
@@ -13,7 +10,7 @@ use num_traits::Zero;
 
 use crate::OpcodeResolutionError;
 
-use super::{get_value, insert_value, witness_to_value};
+use super::{get_value, insert_value, witness_to_value, ErrorLocation};
 
 mod sorting;
 
@@ -74,7 +71,7 @@ pub(super) fn solve_directives(
 
             if b.len() < decomposed_integer.len() {
                 return Err(OpcodeResolutionError::UnsatisfiedConstrain {
-                    opcode_label: OpcodeLabel::Unresolved,
+                    opcode_location: ErrorLocation::Unresolved,
                 });
             }
 

--- a/acvm/src/pwg/memory_op.rs
+++ b/acvm/src/pwg/memory_op.rs
@@ -1,13 +1,13 @@
 use std::collections::HashMap;
 
 use acir::{
-    circuit::{opcodes::MemOp, OpcodeLabel},
+    circuit::opcodes::MemOp,
     native_types::{Witness, WitnessMap},
     FieldElement,
 };
 
-use super::OpcodeResolutionError;
 use super::{arithmetic::ArithmeticSolver, get_value, insert_value, witness_to_value};
+use super::{ErrorLocation, OpcodeResolutionError};
 
 type MemoryIndex = u32;
 
@@ -26,7 +26,7 @@ impl MemoryOpSolver {
     ) -> Result<(), OpcodeResolutionError> {
         if index >= self.block_len {
             return Err(OpcodeResolutionError::IndexOutOfBounds {
-                opcode_label: OpcodeLabel::Unresolved,
+                opcode_location: ErrorLocation::Unresolved,
                 index,
                 array_size: self.block_len,
             });
@@ -37,7 +37,7 @@ impl MemoryOpSolver {
 
     fn read_memory_index(&self, index: MemoryIndex) -> Result<FieldElement, OpcodeResolutionError> {
         self.block_value.get(&index).copied().ok_or(OpcodeResolutionError::IndexOutOfBounds {
-            opcode_label: OpcodeLabel::Unresolved,
+            opcode_location: ErrorLocation::Unresolved,
             index,
             array_size: self.block_len,
         })
@@ -165,7 +165,7 @@ mod tests {
         assert!(matches!(
             err,
             Some(crate::pwg::OpcodeResolutionError::IndexOutOfBounds {
-                opcode_label: _,
+                opcode_location: _,
                 index: 2,
                 array_size: 2
             })

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -284,10 +284,10 @@ impl<B: BlackBoxFunctionSolver> ACVM<B> {
                         brillig_instruction_pointer,
                     ) => {
                         error = OpcodeResolutionError::UnsatisfiedConstrain {
-                            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig(
-                                self.instruction_pointer(),
-                                *brillig_instruction_pointer,
-                            )),
+                            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig {
+                                acir_index: self.instruction_pointer(),
+                                brillig_index: *brillig_instruction_pointer,
+                            }),
                         }
                     }
                     // All other errors are thrown normally.

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -77,6 +77,8 @@ pub enum OpcodeNotSolvable {
     ExpressionHasTooManyUnknowns(Expression),
 }
 
+/// Allows to point to a specific opcode as cause in errors.
+/// Some errors don't have a specific opcode associated with them, or are created without one and added later.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub enum ErrorLocation {
     #[default]

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -620,7 +620,10 @@ fn unsatisfied_opcode_resolved_brillig() {
     assert_eq!(
         solver_status,
         ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig(0, 2))
+            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig {
+                acir_index: 0,
+                brillig_index: 2
+            })
         }),
         "The first gate is not satisfiable, expected an error indicating this"
     );

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -6,14 +6,14 @@ use acir::{
         brillig::{Brillig, BrilligInputs, BrilligOutputs},
         directives::Directive,
         opcodes::{BlockId, MemOp},
-        Opcode, OpcodeLabel,
+        Opcode, OpcodeLocation,
     },
     native_types::{Expression, Witness, WitnessMap},
     FieldElement,
 };
 
 use acvm::{
-    pwg::{ACVMStatus, ForeignCallWaitInfo, OpcodeResolutionError, ACVM},
+    pwg::{ACVMStatus, ErrorLocation, ForeignCallWaitInfo, OpcodeResolutionError, ACVM},
     BlackBoxFunctionSolver,
 };
 use blackbox_solver::BlackBoxResolutionError;
@@ -538,7 +538,7 @@ fn unsatisfied_opcode_resolved() {
     assert_eq!(
         solver_status,
         ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_label: OpcodeLabel::Resolved(0)
+            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Acir(0))
         }),
         "The first gate is not satisfiable, expected an error indicating this"
     );
@@ -620,7 +620,7 @@ fn unsatisfied_opcode_resolved_brillig() {
     assert_eq!(
         solver_status,
         ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_label: OpcodeLabel::Resolved(0)
+            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig(0, 2))
         }),
         "The first gate is not satisfiable, expected an error indicating this"
     );


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

This PR allows to start locating errors inside brillig functions, by exporting a OpcodeLocation struct that can be used to locate both ACIR and Brillig opcodes. Also updated the ACIR optimizer to return a map of new location to old location to support keeping track of location of brillig opcodes.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
