### PR TITLE
feat: print error location with fmt

### DIFF
--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -86,15 +86,26 @@ pub enum ErrorLocation {
     Resolved(OpcodeLocation),
 }
 
+impl std::fmt::Display for ErrorLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ErrorLocation::Unresolved => write!(f, "unresolved"),
+            ErrorLocation::Resolved(location) => {
+                write!(f, "{location}")
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum OpcodeResolutionError {
     #[error("cannot solve opcode: {0}")]
     OpcodeNotSolvable(#[from] OpcodeNotSolvable),
     #[error("backend does not currently support the {0} opcode. ACVM does not currently have a fallback for this opcode.")]
     UnsupportedBlackBoxFunc(BlackBoxFunc),
-    #[error("Cannot satisfy constraint {opcode_location:?}")]
+    #[error("Cannot satisfy constraint {opcode_location}")]
     UnsatisfiedConstrain { opcode_location: ErrorLocation },
-    #[error("Index out of bounds, array has size {array_size:?}, but index was {index:?}")]
+    #[error("Index out of bounds, array has size {array_size:?}, but index was {index:?} at {opcode_location}")]
     IndexOutOfBounds { opcode_location: ErrorLocation, index: u32, array_size: u32 },
     #[error("failed to solve blackbox function: {0}, reason: {1}")]
     BlackBoxFunctionFailed(BlackBoxFunc, String),


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*
Updates the string representation of opcode locations with fmt for easy parsing.
<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->


## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
