### PR TITLE
chore: split `BlackBoxFunctionSolver` off from `Backend` trait

### DIFF
--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -32,12 +32,7 @@ pub enum Language {
 }
 
 pub trait Backend:
-    SmartContract
-    + ProofSystemCompiler
-    + BlackBoxFunctionSolver
-    + CommonReferenceString
-    + Default
-    + Debug
+    SmartContract + ProofSystemCompiler + CommonReferenceString + Default + Debug
 {
 }
 


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Prerequisite for #492 

## Summary\*

This PR separates the `BlackBoxFunctionSolver` trait from the `Backend` trait. This is a necessary step for #492 as these will become two distinct entities.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
