### PR TITLE
feat: Implement `Char` from `FieldElement`

### DIFF
--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -111,6 +111,15 @@ impl<F: PrimeField> From<i128> for FieldElement<F> {
     }
 }
 
+impl<F: PrimeField> From<FieldElement<F>> for char {
+    fn from(element: FieldElement<F>) -> Self {
+        let mut field_as_bytes = element.to_be_bytes();
+        let char_byte = field_as_bytes.pop().expect("The last byte should be a char"); // A character in a string is represented by a u8, thus we just want the last byte of the element
+        assert!(field_as_bytes.into_iter().all(|b| b == 0)); // Assert that the rest of the field element's bytes are empty
+        char_byte as char
+    }
+}
+
 impl<T: ark_ff::PrimeField> Serialize for FieldElement<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

While working on https://github.com/noir-lang/noir/pull/2373, I noticed that we have code that converts a `FieldElement` into a `char` so we can collect them into a `String`. This adds a proper `From` implementation so we don't need the custom code like https://github.com/noir-lang/noir/blob/master/crates/noirc_abi/src/lib.rs#L394-L399

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
