### PR TITLE
chore(acvm)!: remove `CommonReferenceString` trait and preprocess method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,6 @@ dependencies = [
  "acir",
  "acvm_blackbox_solver",
  "acvm_stdlib",
- "async-trait",
  "brillig_vm",
  "indexmap",
  "num-bigint",
@@ -292,17 +291,6 @@ name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
-
-[[package]]
-name = "async-trait"
-version = "0.1.72"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
 
 [[package]]
 name = "autocfg"

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -21,7 +21,6 @@ brillig_vm = { version = "0.22.0", path = "../brillig_vm", default-features = fa
 blackbox_solver.workspace = true
 
 indexmap = "1.7.0"
-async-trait = "0.1"
 
 [features]
 default = ["bn254", "testing"]

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -61,14 +61,6 @@ pub trait ProofSystemCompiler {
     /// Returns the number of gates in a circuit
     fn get_exact_circuit_size(&self, circuit: &Circuit) -> Result<u32, Self::Error>;
 
-    /// Generates a proving and verification key given the circuit description
-    /// These keys can then be used to construct a proof and for its verification
-    fn preprocess(
-        &self,
-        common_reference_string: &[u8],
-        circuit: &Circuit,
-    ) -> Result<(Vec<u8>, Vec<u8>), Self::Error>;
-
     /// Creates a Proof given the circuit description, the initial witness values, and the proving key
     /// It is important to note that the intermediate witnesses for black box functions will not generated
     /// This is the responsibility of the proof system.

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -31,41 +31,7 @@ pub enum Language {
     PLONKCSat { width: usize },
 }
 
-pub trait Backend:
-    SmartContract + ProofSystemCompiler + CommonReferenceString + Default + Debug
-{
-}
-
-// Unfortunately, Rust doesn't natively allow async functions in traits yet.
-// So we need to annotate our trait with this macro and backends need to attach the macro to their `impl`.
-//
-// For more details, see https://docs.rs/async-trait/latest/async_trait/
-// and https://smallcultfollowing.com/babysteps/blog/2019/10/26/async-fn-in-traits-are-hard/
-#[async_trait(?Send)]
-pub trait CommonReferenceString {
-    /// The Error type returned by failed function calls in the CommonReferenceString trait.
-    type Error: std::error::Error; // fully-qualified named because thiserror is `use`d at the top of the crate
-
-    /// Provides the common reference string that is needed by other traits
-    async fn generate_common_reference_string(
-        &self,
-        circuit: &Circuit,
-    ) -> Result<Vec<u8>, Self::Error>;
-
-    /// Updates a cached common reference string within the context of a circuit
-    ///
-    /// This function will be called if the common reference string has been cached previously
-    /// and the backend can update it if necessary. This may happen if the common reference string
-    /// contains fewer than the number of points needed by the circuit, or fails any other checks the backend
-    /// must perform.
-    ///
-    /// If the common reference string doesn't need any updates, implementors can return the value passed.
-    async fn update_common_reference_string(
-        &self,
-        common_reference_string: Vec<u8>,
-        circuit: &Circuit,
-    ) -> Result<Vec<u8>, Self::Error>;
-}
+pub trait Backend: SmartContract + ProofSystemCompiler + Default + Debug {}
 
 pub trait SmartContract {
     /// The Error type returned by failed function calls in the SmartContract trait.

--- a/acvm/src/lib.rs
+++ b/acvm/src/lib.rs
@@ -12,9 +12,6 @@ pub use blackbox_solver::{BlackBoxFunctionSolver, BlackBoxResolutionError};
 use core::fmt::Debug;
 use pwg::OpcodeResolutionError;
 
-// We re-export async-trait so consumers can attach it to their impl
-pub use async_trait::async_trait;
-
 // re-export acir
 pub use acir;
 pub use acir::FieldElement;


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This is no longer needed when using dynamic backends.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
