### PR TITLE
chore: download the wasm binary in build.rs if no env var is provided

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,7 +54,6 @@ name = "acvm_blackbox_solver"
 version = "0.22.0"
 dependencies = [
  "acir",
- "base64ct",
  "blake2",
  "flate2",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ name = "acvm_blackbox_solver"
 version = "0.22.0"
 dependencies = [
  "acir",
+ "base64ct",
  "blake2",
  "flate2",
  "getrandom",
@@ -61,6 +62,7 @@ dependencies = [
  "k256",
  "p256",
  "pkg-config",
+ "reqwest",
  "rust-embed",
  "sha2",
  "sha3",
@@ -330,6 +332,12 @@ name = "base16ct"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base64"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
 name = "base64ct"
@@ -854,6 +862,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-iterator"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -981,6 +998,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,6 +1144,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,6 +1214,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d78e1e73ec14cf7375674f74d7dde185c8206fd9dea6fb6295e8a98098aaa97"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,6 +1333,12 @@ dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itertools"
@@ -1300,12 +1474,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1411,6 +1602,12 @@ name = "pin-project-lite"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
@@ -1687,6 +1884,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1931,21 @@ dependencies = [
  "crypto-bigint",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1813,6 +2064,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2271,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "slice-group-by"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,6 +2348,32 @@ name = "smallvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -2182,6 +2521,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2 0.5.3",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
 name = "tracing"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,6 +2597,12 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -2259,6 +2650,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2695,15 @@ checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2622,6 +3028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,6 +3181,16 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "wyz"

--- a/blackbox_solver/Cargo.toml
+++ b/blackbox_solver/Cargo.toml
@@ -53,8 +53,8 @@ wasmer = "3.3"
 
 [build-dependencies]
 pkg-config = "0.3"
-base64ct = { version = "1.6.0", features = ["alloc"] }
-sha2 = "0.10.6"
+#base64ct = { version = "1.6.0", features = ["alloc"] }
+#sha2 = "0.10.6"
 tar = "~0.4.15"
 flate2 = "~1.0.1"
 reqwest = { version = "0.11.16", default-features = false, features = [

--- a/blackbox_solver/Cargo.toml
+++ b/blackbox_solver/Cargo.toml
@@ -53,8 +53,6 @@ wasmer = "3.3"
 
 [build-dependencies]
 pkg-config = "0.3"
-#base64ct = { version = "1.6.0", features = ["alloc"] }
-#sha2 = "0.10.6"
 tar = "~0.4.15"
 flate2 = "~1.0.1"
 reqwest = { version = "0.11.16", default-features = false, features = [

--- a/blackbox_solver/Cargo.toml
+++ b/blackbox_solver/Cargo.toml
@@ -53,8 +53,14 @@ wasmer = "3.3"
 
 [build-dependencies]
 pkg-config = "0.3"
+base64ct = { version = "1.6.0", features = ["alloc"] }
+sha2 = "0.10.6"
 tar = "~0.4.15"
 flate2 = "~1.0.1"
+reqwest = { version = "0.11.16", default-features = false, features = [
+    "rustls-tls",
+    "blocking",
+] }
 
 [features]
 default = ["bn254"]

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -33,7 +33,6 @@ fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
 
 /// Try to download the specified URL into a buffer which is returned.
 fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
-
     let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
 
     let bytes = response.bytes().unwrap();

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -4,16 +4,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use base64ct::{Base64, Encoding};
-use flate2::read::GzDecoder;
-use sha2::Sha256;
-use tar::Archive;
-
 const BARRETENBERG_ARCHIVE: &str = "BARRETENBERG_ARCHIVE";
 const BARRETENBERG_BIN_DIR: &str = "BARRETENBERG_BIN_DIR";
 
-const BARRETENBERG_ARCHIVE_FALLBACK: &str = "https://github.com/AztecProtocol/barretenberg/releases/download/barretenberg-v0.4.5/acvm_backend.wasm.tar.gz";
-const ARCHIVE_SHA256: &str = "0z24yhvxc0dr13xj7y4xs9p42lzxwpazrmsrdpcgynfajkk6vqy4";
+const BARRETENBERG_ARCHIVE_FALLBACK: &str = "https://github.com/AztecProtocol/barretenberg/releases/download/barretenberg-v0.4.6/acvm_backend.wasm.tar.gz";
+const ARCHIVE_SHA256: &str = "1xpycikqlvsjcryi3hkbc4mwmmdz7zshw6f76vyf1qssq53asyfx";
 
 fn unpack_wasm(archive_path: &Path, target_dir: &Path) -> Result<(), String> {
     if archive_path.exists() && archive_path.is_file() {
@@ -27,6 +22,9 @@ fn unpack_wasm(archive_path: &Path, target_dir: &Path) -> Result<(), String> {
 }
 
 fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
+    use flate2::read::GzDecoder;
+    use tar::Archive;
+
     let gz_decoder = GzDecoder::new(archive);
     let mut archive = Archive::new(gz_decoder);
 
@@ -35,7 +33,8 @@ fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
 
 /// Try to download the specified URL into a buffer which is returned.
 fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
-    use sha2::Digest;
+    use base64ct::{Base64, Encoding};
+    use sha2::{Digest, Sha256};
 
     let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
 

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -33,8 +33,6 @@ fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
 
 /// Try to download the specified URL into a buffer which is returned.
 fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
-    // use base64ct::{Base64, Encoding};
-    // use sha2::{Digest, Sha256};
 
     let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
 

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -8,7 +8,7 @@ const BARRETENBERG_ARCHIVE: &str = "BARRETENBERG_ARCHIVE";
 const BARRETENBERG_BIN_DIR: &str = "BARRETENBERG_BIN_DIR";
 
 const BARRETENBERG_ARCHIVE_FALLBACK: &str = "https://github.com/AztecProtocol/barretenberg/releases/download/barretenberg-v0.4.6/acvm_backend.wasm.tar.gz";
-const ARCHIVE_SHA256: &str = "1xpycikqlvsjcryi3hkbc4mwmmdz7zshw6f76vyf1qssq53asyfx";
+// const ARCHIVE_SHA256: &str = "1xpycikqlvsjcryi3hkbc4mwmmdz7zshw6f76vyf1qssq53asyfx";
 
 fn unpack_wasm(archive_path: &Path, target_dir: &Path) -> Result<(), String> {
     if archive_path.exists() && archive_path.is_file() {
@@ -33,16 +33,16 @@ fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
 
 /// Try to download the specified URL into a buffer which is returned.
 fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
-    use base64ct::{Base64, Encoding};
-    use sha2::{Digest, Sha256};
+    // use base64ct::{Base64, Encoding};
+    // use sha2::{Digest, Sha256};
 
     let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
 
     let bytes = response.bytes().unwrap();
 
-    let digest = Sha256::digest(bytes.clone());
-    let base64_digest = Base64::encode_string(&digest);
-    assert_eq!(base64_digest, ARCHIVE_SHA256);
+    // let digest = Sha256::digest(bytes.clone());
+    // let base64_digest = Base64::encode_string(&digest);
+    // assert_eq!(base64_digest, ARCHIVE_SHA256);
 
     Ok(Cursor::new(bytes.to_vec()))
 }

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -37,11 +37,6 @@ fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
     let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
 
     let bytes = response.bytes().unwrap();
-
-    // let digest = Sha256::digest(bytes.clone());
-    // let base64_digest = Base64::encode_string(&digest);
-    // assert_eq!(base64_digest, ARCHIVE_SHA256);
-
     Ok(Cursor::new(bytes.to_vec()))
 }
 

--- a/blackbox_solver/build.rs
+++ b/blackbox_solver/build.rs
@@ -1,26 +1,51 @@
 use std::{
     fs::File,
+    io::{Cursor, Read},
     path::{Path, PathBuf},
 };
 
+use base64ct::{Base64, Encoding};
 use flate2::read::GzDecoder;
+use sha2::Sha256;
 use tar::Archive;
 
-const BARRETENBERG_ARCHIVE: &&str = &"BARRETENBERG_ARCHIVE";
-const BARRETENBERG_BIN_DIR: &&str = &"BARRETENBERG_BIN_DIR";
+const BARRETENBERG_ARCHIVE: &str = "BARRETENBERG_ARCHIVE";
+const BARRETENBERG_BIN_DIR: &str = "BARRETENBERG_BIN_DIR";
+
+const BARRETENBERG_ARCHIVE_FALLBACK: &str = "https://github.com/AztecProtocol/barretenberg/releases/download/barretenberg-v0.4.5/acvm_backend.wasm.tar.gz";
+const ARCHIVE_SHA256: &str = "0z24yhvxc0dr13xj7y4xs9p42lzxwpazrmsrdpcgynfajkk6vqy4";
 
 fn unpack_wasm(archive_path: &Path, target_dir: &Path) -> Result<(), String> {
     if archive_path.exists() && archive_path.is_file() {
         let archive = File::open(archive_path).map_err(|_| "Could not read archive")?;
-        let gz_decoder: GzDecoder<File> = GzDecoder::new(archive);
-        let mut archive = Archive::new(gz_decoder);
-
-        archive.unpack(target_dir).unwrap();
+        unpack_archive(archive, target_dir);
 
         Ok(())
     } else {
         Err(format!("Unable to locate {BARRETENBERG_ARCHIVE} - Please set the BARRETENBERG_BIN_DIR env var to the directory where it exists, or ensure it's located at {}", archive_path.display()))
     }
+}
+
+fn unpack_archive<T: Read>(archive: T, target_dir: &Path) {
+    let gz_decoder = GzDecoder::new(archive);
+    let mut archive = Archive::new(gz_decoder);
+
+    archive.unpack(target_dir).unwrap();
+}
+
+/// Try to download the specified URL into a buffer which is returned.
+fn download_binary_from_url(url: &str) -> Result<Cursor<Vec<u8>>, String> {
+    use sha2::Digest;
+
+    let response = reqwest::blocking::get(url).map_err(|error| error.to_string())?;
+
+    let bytes = response.bytes().unwrap();
+
+    let digest = Sha256::digest(bytes.clone());
+    let base64_digest = Base64::encode_string(&digest);
+    assert_eq!(base64_digest, ARCHIVE_SHA256);
+
+    Ok(Cursor::new(bytes.to_vec()))
 }
 
 fn main() -> Result<(), String> {
@@ -32,6 +57,14 @@ fn main() -> Result<(), String> {
             println!("cargo:rustc-env={BARRETENBERG_BIN_DIR}={out_dir}");
             Ok(())
         }
-        Err(error) => Err(error.to_string()),
+        Err(_) => {
+            let wasm_bytes = download_binary_from_url(BARRETENBERG_ARCHIVE_FALLBACK)
+                .expect("download should succeed");
+
+            unpack_archive(wasm_bytes, &PathBuf::from(&out_dir));
+            println!("cargo:rustc-env={BARRETENBERG_BIN_DIR}={out_dir}");
+
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This removes the necessity for consumers of ACVM to download the wasm themselves and set the environment variable.

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
