### PR TITLE
chore: Remove BTreeMap type on assert_messages 

### DIFF
--- a/acvm/src/compiler/mod.rs
+++ b/acvm/src/compiler/mod.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use acir::{
     circuit::{
         brillig::BrilligOutputs, directives::Directive, opcodes::UnsupportedMemoryOpcode, Circuit,
@@ -61,9 +59,9 @@ impl AcirTransformationMap {
 }
 
 fn transform_assert_messages(
-    assert_messages: BTreeMap<OpcodeLocation, String>,
+    assert_messages: Vec<(OpcodeLocation, String)>,
     map: &AcirTransformationMap,
-) -> BTreeMap<OpcodeLocation, String> {
+) -> Vec<(OpcodeLocation, String)> {
     assert_messages
         .into_iter()
         .flat_map(|(location, message)| {

--- a/acvm/src/compiler/optimizers/redundant_range.rs
+++ b/acvm/src/compiler/optimizers/redundant_range.rs
@@ -135,7 +135,7 @@ fn extract_range_opcode(opcode: &Opcode) -> Option<(Witness, u32)> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::collections::BTreeSet;
 
     use crate::compiler::optimizers::redundant_range::{extract_range_opcode, RangeOptimizer};
     use acir::{
@@ -164,7 +164,7 @@ mod tests {
             private_parameters: BTreeSet::new(),
             public_parameters: PublicInputs::default(),
             return_values: PublicInputs::default(),
-            assert_messages: BTreeMap::new(),
+            assert_messages: Default::default(),
         }
     }
 

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -4,7 +4,6 @@ use acir::{
     brillig::{BinaryFieldOp, Opcode as BrilligOpcode, RegisterIndex, RegisterOrMemory, Value},
     circuit::{
         brillig::{Brillig, BrilligInputs, BrilligOutputs},
-        directives::Directive,
         opcodes::{BlockId, MemOp},
         Opcode, OpcodeLocation,
     },

--- a/acvm_js/src/execute.rs
+++ b/acvm_js/src/execute.rs
@@ -1,6 +1,6 @@
 #[allow(deprecated)]
 use acvm::{
-    acir::circuit::Circuit,
+    acir::circuit::{Circuit, OpcodeLocation},
     blackbox_solver::BarretenbergSolver,
     pwg::{ACVMStatus, ErrorLocation, OpcodeResolutionError, ACVM},
 };
@@ -83,7 +83,7 @@ pub async fn execute_circuit_with_black_box_solver(
                     | OpcodeResolutionError::IndexOutOfBounds {
                         opcode_location: ErrorLocation::Resolved(opcode_location),
                         ..
-                    } => circuit.assert_messages.get(opcode_location).cloned(),
+                    } => get_assert_message(&circuit.assert_messages, opcode_location),
                     _ => None,
                 };
 
@@ -104,4 +104,16 @@ pub async fn execute_circuit_with_black_box_solver(
 
     let witness_map = acvm.finalize();
     Ok(witness_map.into())
+}
+
+// Searches the slice for `opcode_location`.
+// This is functionality equivalent to .get on a map.
+fn get_assert_message(
+    assert_messages: &[(OpcodeLocation, String)],
+    opcode_location: &OpcodeLocation,
+) -> Option<String> {
+    assert_messages
+        .iter()
+        .find(|(loc, _)| loc == opcode_location)
+        .map(|(_, message)| message.clone())
 }


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

This temporarily removes the BTreeMap type for assert messages. For now, this will be more inefficient.

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
