### PR TITLE
feat!: Provide runtime callstacks for brillig failures and return errors in acvm_js

### DIFF
--- a/acvm/src/pwg/brillig.rs
+++ b/acvm/src/pwg/brillig.rs
@@ -1,6 +1,9 @@
 use acir::{
     brillig::{RegisterIndex, Value},
-    circuit::brillig::{Brillig, BrilligInputs, BrilligOutputs},
+    circuit::{
+        brillig::{Brillig, BrilligInputs, BrilligOutputs},
+        OpcodeLocation,
+    },
     native_types::WitnessMap,
     FieldElement,
 };
@@ -18,6 +21,7 @@ impl BrilligSolver {
         initial_witness: &mut WitnessMap,
         brillig: &Brillig,
         bb_solver: &B,
+        acir_index: usize,
     ) -> Result<Option<ForeignCallWaitInfo>, OpcodeResolutionError> {
         // If the predicate is `None`, then we simply return the value 1
         // If the predicate is `Some` but we cannot find a value, then we return stalled
@@ -107,8 +111,17 @@ impl BrilligSolver {
                 Ok(None)
             }
             VMStatus::InProgress => unreachable!("Brillig VM has not completed execution"),
-            VMStatus::Failure { message } => {
-                Err(OpcodeResolutionError::BrilligFunctionFailed(message, vm.program_counter()))
+            VMStatus::Failure { message, call_stack } => {
+                Err(OpcodeResolutionError::BrilligFunctionFailed {
+                    message,
+                    call_stack: call_stack
+                        .iter()
+                        .map(|brillig_index| OpcodeLocation::Brillig {
+                            acir_index,
+                            brillig_index: *brillig_index,
+                        })
+                        .collect(),
+                })
             }
             VMStatus::ForeignCallWait { function, inputs } => {
                 Ok(Some(ForeignCallWaitInfo { function, inputs }))

--- a/acvm/src/pwg/mod.rs
+++ b/acvm/src/pwg/mod.rs
@@ -99,15 +99,15 @@ impl std::fmt::Display for ErrorLocation {
 
 #[derive(Clone, PartialEq, Eq, Debug, Error)]
 pub enum OpcodeResolutionError {
-    #[error("cannot solve opcode: {0}")]
+    #[error("Cannot solve opcode: {0}")]
     OpcodeNotSolvable(#[from] OpcodeNotSolvable),
-    #[error("backend does not currently support the {0} opcode. ACVM does not currently have a fallback for this opcode.")]
+    #[error("Backend does not currently support the {0} opcode. ACVM does not currently have a fallback for this opcode.")]
     UnsupportedBlackBoxFunc(BlackBoxFunc),
     #[error("Cannot satisfy constraint")]
     UnsatisfiedConstrain { opcode_location: ErrorLocation },
     #[error("Index out of bounds, array has size {array_size:?}, but index was {index:?}")]
     IndexOutOfBounds { opcode_location: ErrorLocation, index: u32, array_size: u32 },
-    #[error("failed to solve blackbox function: {0}, reason: {1}")]
+    #[error("Failed to solve blackbox function: {0}, reason: {1}")]
     BlackBoxFunctionFailed(BlackBoxFunc, String),
     #[error("Failed to solve brillig function, reason: {message}")]
     BrilligFunctionFailed { message: String, call_stack: Vec<OpcodeLocation> },

--- a/acvm/tests/solver.rs
+++ b/acvm/tests/solver.rs
@@ -4,7 +4,6 @@ use acir::{
     brillig::{BinaryFieldOp, Opcode as BrilligOpcode, RegisterIndex, RegisterOrMemory, Value},
     circuit::{
         brillig::{Brillig, BrilligInputs, BrilligOutputs},
-        directives::Directive,
         opcodes::{BlockId, MemOp},
         Opcode, OpcodeLocation,
     },
@@ -599,11 +598,9 @@ fn unsatisfied_opcode_resolved_brillig() {
     let solver_status = acvm.solve();
     assert_eq!(
         solver_status,
-        ACVMStatus::Failure(OpcodeResolutionError::UnsatisfiedConstrain {
-            opcode_location: ErrorLocation::Resolved(OpcodeLocation::Brillig {
-                acir_index: 0,
-                brillig_index: 2
-            }),
+        ACVMStatus::Failure(OpcodeResolutionError::BrilligFunctionFailed {
+            message: "explicit trap hit in brillig".to_string(),
+            call_stack: vec![OpcodeLocation::Brillig { acir_index: 0, brillig_index: 2 }]
         }),
         "The first opcode is not satisfiable, expected an error indicating this"
     );

--- a/acvm_js/src/execute.rs
+++ b/acvm_js/src/execute.rs
@@ -100,7 +100,7 @@ pub async fn execute_circuit_with_black_box_solver(
                 };
 
                 let error_string = match &assert_message {
-                    Some(assert_message) => format!("{}: {}", error, assert_message),
+                    Some(assert_message) => format!("Assertion failed: {}", assert_message),
                     None => error.to_string(),
                 };
 

--- a/acvm_js/src/execute.rs
+++ b/acvm_js/src/execute.rs
@@ -99,17 +99,12 @@ pub async fn execute_circuit_with_black_box_solver(
                     _ => (None, None),
                 };
 
-                let error_string = match assert_message {
+                let error_string = match &assert_message {
                     Some(assert_message) => format!("{}: {}", error, assert_message),
                     None => error.to_string(),
                 };
 
-                let mut err = JsExecutionError::new(error_string.into());
-                if let Some(call_stack) = call_stack {
-                    err.set_call_stack(call_stack);
-                }
-
-                return Err(err.into());
+                return Err(JsExecutionError::new(error_string.into(), call_stack).into());
             }
             ACVMStatus::RequiresForeignCall(foreign_call) => {
                 let result = resolve_brillig(&foreign_call_handler, &foreign_call).await?;

--- a/acvm_js/src/execute.rs
+++ b/acvm_js/src/execute.rs
@@ -104,7 +104,12 @@ pub async fn execute_circuit_with_black_box_solver(
                     None => error.to_string(),
                 };
 
-                return Err(JsExecutionError::create(error_string, call_stack).into());
+                let mut err = JsExecutionError::new(error_string.into());
+                if let Some(call_stack) = call_stack {
+                    err.set_call_stack(call_stack);
+                }
+
+                return Err(err.into());
             }
             ACVMStatus::RequiresForeignCall(foreign_call) => {
                 let result = resolve_brillig(&foreign_call_handler, &foreign_call).await?;

--- a/acvm_js/src/js/executionError.js
+++ b/acvm_js/src/js/executionError.js
@@ -1,6 +1,0 @@
-export class ExecutionError extends Error {
-  constructor(message, callStack) {
-    super(message);
-    this.callStack = callStack;
-  }
-}

--- a/acvm_js/src/js/executionError.js
+++ b/acvm_js/src/js/executionError.js
@@ -1,0 +1,6 @@
+export class ExecutionError extends Error {
+  constructor(message, callStack) {
+    super(message);
+    this.callStack = callStack;
+  }
+}

--- a/acvm_js/src/js_execution_error.rs
+++ b/acvm_js/src/js_execution_error.rs
@@ -1,0 +1,38 @@
+use gloo_utils::format::JsValueSerdeExt;
+use js_sys::{Error, JsString};
+use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
+
+use acvm::acir::circuit::OpcodeLocation;
+
+#[wasm_bindgen(typescript_custom_section)]
+const EXECUTION_ERROR: &'static str = r#"
+export class ExecutionError extends Error {
+    constructor(message: string, private callStack?: string[]) {
+        super(message);
+    }
+}
+"#;
+
+// ExecutionError
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(extends = Error, js_name = "ExecutionError", typescript_type = "ExecutionError")]
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    pub type JsExecutionError;
+
+    #[wasm_bindgen(constructor, js_class = "ExecutionError")]
+    pub fn new(message: JsString, call_stack: JsValue) -> JsExecutionError;
+}
+
+impl JsExecutionError {
+    pub fn create(message: String, call_stack: Option<Vec<OpcodeLocation>>) -> JsExecutionError {
+        let call_stack = match call_stack {
+            Some(call_stack) => {
+                let call_stack: Vec<_> = call_stack.iter().map(|loc| format!("{}", loc)).collect();
+                <JsValue as JsValueSerdeExt>::from_serde(&call_stack).unwrap()
+            }
+            None => JsValue::UNDEFINED,
+        };
+        JsExecutionError::new(JsString::from(message).into(), call_stack)
+    }
+}

--- a/acvm_js/src/js_execution_error.rs
+++ b/acvm_js/src/js_execution_error.rs
@@ -1,38 +1,38 @@
 use acvm::acir::circuit::OpcodeLocation;
-use js_sys::{Array, Error, JsString};
+use js_sys::{Array, Error, JsString, Reflect};
 use wasm_bindgen::prelude::{wasm_bindgen, JsValue};
 
 #[wasm_bindgen(typescript_custom_section)]
 const EXECUTION_ERROR: &'static str = r#"
-export declare class ExecutionError extends Error {
-    callStack?: string[] | undefined;
-    constructor(message: string, callStack?: string[] | undefined);
-}
+export type ExecutionError = Error & {
+    callStack?: string[];
+};
 "#;
 
-// ExecutionError
-#[wasm_bindgen(module = "src/js/executionError.js")]
+/// JsExecutionError is a raw js error.
+/// It'd be ideal that execution error was a subclass of Error, but for that we'd need to use JS snippets or a js module.
+/// Currently JS snippets don't work with a nodejs target. And a module would be too much for just a custom error type.
+#[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends = Error, js_name = "ExecutionError", typescript_type = "ExecutionError")]
     #[derive(Clone, Debug, PartialEq, Eq)]
     pub type JsExecutionError;
 
-    #[wasm_bindgen(constructor, js_class = "ExecutionError")]
-    pub fn new(message: JsString, call_stack: JsValue) -> JsExecutionError;
+    #[wasm_bindgen(constructor, js_class = "Error")]
+    pub fn new(message: JsString) -> JsExecutionError;
 }
 
 impl JsExecutionError {
-    pub fn create(message: String, call_stack: Option<Vec<OpcodeLocation>>) -> JsExecutionError {
-        let call_stack = match call_stack {
-            Some(call_stack) => {
-                let js_array = Array::new();
-                for loc in call_stack {
-                    js_array.push(&JsValue::from(format!("{}", loc)));
-                }
-                js_array.into()
-            }
-            None => JsValue::UNDEFINED,
-        };
-        JsExecutionError::new(JsString::from(message).into(), call_stack)
+    /// Sets the call stack in an execution error.
+    pub fn set_call_stack(&mut self, call_stack: Vec<OpcodeLocation>) {
+        let js_array = Array::new();
+        for loc in call_stack {
+            js_array.push(&JsValue::from(format!("{}", loc)));
+        }
+        assert!(
+            Reflect::set(self, &JsValue::from("callStack"), &js_array)
+                .expect("Errors should be objects"),
+            "Errors should be writable"
+        );
     }
 }

--- a/acvm_js/src/lib.rs
+++ b/acvm_js/src/lib.rs
@@ -14,6 +14,7 @@ cfg_if::cfg_if! {
         mod js_witness_map;
         mod logging;
         mod public_witness;
+        mod js_execution_error;
 
         pub use build_info::build_info;
         pub use compression::{compress_witness, decompress_witness};
@@ -21,6 +22,6 @@ cfg_if::cfg_if! {
         pub use js_witness_map::JsWitnessMap;
         pub use logging::{init_log_level, LogLevel};
         pub use public_witness::{get_public_parameters_witness, get_public_witness, get_return_witness};
-
+        pub use js_execution_error::JsExecutionError;
     }
 }

--- a/brillig_vm/src/lib.rs
+++ b/brillig_vm/src/lib.rs
@@ -30,13 +30,16 @@ pub use memory::Memory;
 use num_bigint::BigUint;
 pub use registers::Registers;
 
+/// The error call stack contains the opcode indexes of the call stack at the time of failure, plus the index of the opcode that failed.
+pub type ErrorCallStack = Vec<usize>;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum VMStatus {
     Finished,
     InProgress,
     Failure {
         message: String,
-        call_stack: Vec<usize>,
+        call_stack: ErrorCallStack,
     },
     /// The VM process is not solvable as a [foreign call][Opcode::ForeignCall] has been
     /// reached where the outputs are yet to be resolved.  


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

ACVM part of https://github.com/noir-lang/noir/issues/2550

 - Brillig errors were never emitted from the ACVM, they were changed to an unsatisfied constraint error. Now they are emitted and they contain a call stack instead of a failing opcode, to be able to provide call stacks for brillig functions which are not inlined.
 - Also, the acvm_js was throwing strings instead of errors. Now it throws JS errors and in the case of an execution failure, an error with a call stack property.
 - Since the acvm_js now returns the failing opcode locations in a structured way, we can remove insertion of indices in OpcodeResolutionError

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
