### PR TITLE
fix: initialize recursive proof output to zero

### DIFF
--- a/acvm/src/pwg/blackbox/mod.rs
+++ b/acvm/src/pwg/blackbox/mod.rs
@@ -152,7 +152,7 @@ pub(crate) fn solve(
             fixed_base_scalar_mul(backend, initial_witness, *input, *outputs)
         }
         BlackBoxFuncCall::RecursiveAggregation { output_aggregation_object, .. } => {
-            // Solve the output of the recursive aggregation to zero to prevent missing assignement errors
+            // Solve the output of the recursive aggregation to zero to prevent missing assignment errors
             // The correct value will be computed by the backend
             for witness in output_aggregation_object {
                 insert_value(witness, FieldElement::zero(), initial_witness)?;


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Recursive aggregation opcode is solved by the backend and cannot be solved by acvm. This can lead to missing assignment errors during execution.

Resolves <!-- Link to GitHub Issue -->

To prevent these errors, we solve the opcode with zeros. The backend will resolved it properly after.

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [X] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
