### PR TITLE
fix: Update `FieldElement.num_bits()` to return 1 for a zero field element

### DIFF
--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -212,7 +212,8 @@ impl<F: PrimeField> FieldElement<F> {
 
     /// This is the number of bits required to represent this specific field element
     pub fn num_bits(&self) -> u32 {
-        if self.is_zero() { // now returns one for a zero field element
+        if self.is_zero() {
+            // now returns one for a zero field element
             return 1;
         }
         let bits = self.bits();

--- a/acir_field/src/generic_ark.rs
+++ b/acir_field/src/generic_ark.rs
@@ -212,6 +212,9 @@ impl<F: PrimeField> FieldElement<F> {
 
     /// This is the number of bits required to represent this specific field element
     pub fn num_bits(&self) -> u32 {
+        if self.is_zero() { // now returns one for a zero field element
+            return 1;
+        }
         let bits = self.bits();
         // Iterate the number of bits and pop off all leading zeroes
         let iter = bits.iter().skip_while(|x| !(**x));
@@ -440,6 +443,21 @@ mod tests {
     fn max_num_bits_smoke() {
         let max_num_bits_bn254 = crate::generic_ark::FieldElement::<ark_bn254::Fr>::max_num_bits();
         assert_eq!(max_num_bits_bn254, 254)
+    }
+
+    #[test]
+    fn num_bits_smoke() {
+        let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(0 as i128);
+
+        assert_eq!(1, x.num_bits());
+
+        let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(1 as i128);
+
+        assert_eq!(1, x.num_bits());
+
+        let x = crate::generic_ark::FieldElement::<ark_bn254::Fr>::from(1000000 as i128);
+
+        assert_eq!(20, x.num_bits());
     }
 }
 


### PR DESCRIPTION
# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves noir-lang/noir#4759 

## Summary\*

`num_bits` function now returns 1 for a zero field element
Added test for `num_bits` function

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
