### PR TITLE
chore(ci): install `wasm-bindgen-cli` through prebuilt binary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --vers "0.2.87" --locked
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen-cli@0.2.87
 
       - name: Run rust tests
         run: cargo test


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This uses the https://github.com/taiki-e/install-action action to install `wasm-bindgen-cli`. Under the hood this is using `cargo-binstall` which is listed as a [supported install method](https://github.com/rustwasm/wasm-bindgen#install-wasm-bindgen-cli)

This ends up shaving ~4mins off of CI

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
