### PR TITLE
fix: use the exact version for the hex crate

### DIFF
--- a/blackbox_solver/Cargo.toml
+++ b/blackbox_solver/Cargo.toml
@@ -31,7 +31,7 @@ p256 = { version = "0.11.0", features = [
     "digest",
     "arithmetic",
 ] }
-hex = "*"
+hex = "0.4.2"
 num-bigint.workspace = true
 
 # Barretenberg WASM dependencies


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Cargo does not allow one to publish to crates.io with wildcards

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
