### PR TITLE
chore: fix release-please config for `acvm_backend_solver`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ acir = { version = "0.26.1", path = "acir", default-features = false }
 acir_field = { version = "0.26.1", path = "acir_field", default-features = false }
 stdlib = { package = "acvm_stdlib", version = "0.26.1", path = "stdlib", default-features = false }
 brillig = { version = "0.26.1", path = "brillig", default-features = false }
+brillig_vm = { version = "0.26.1", path = "brillig_vm", default-features = false }
 acvm_blackbox_solver = { version = "0.26.1", path = "blackbox_solver", default-features = false }
 barretenberg_blackbox_solver = { version = "0.26.1", path = "barretenberg_blackbox_solver", default-features = false }
 

--- a/acvm/Cargo.toml
+++ b/acvm/Cargo.toml
@@ -17,7 +17,7 @@ thiserror.workspace = true
 
 acir.workspace = true
 stdlib.workspace = true
-brillig_vm = { version = "0.26.1", path = "../brillig_vm", default-features = false }
+brillig_vm.workspace = true
 acvm_blackbox_solver.workspace = true
 
 indexmap = "1.7.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,7 +31,7 @@
         {
           "type": "toml",
           "path": "Cargo.toml",
-          "jsonpath": "$.workspace.dependencies.blackbox_solver.version"
+          "jsonpath": "$.workspace.dependencies.acvm_blackbox_solver.version"
         },
         {
           "type": "json",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

This PR ensures that release please will properly update the `acvm_blackbox_solver` dependency in `Cargo.toml`

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
