### PR TITLE
chore: bump `brillig_vm` version in release please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -31,6 +31,11 @@
         {
           "type": "toml",
           "path": "Cargo.toml",
+          "jsonpath": "$.workspace.dependencies.brillig_vm.version"
+        },
+        {
+          "type": "toml",
+          "path": "Cargo.toml",
           "jsonpath": "$.workspace.dependencies.acvm_blackbox_solver.version"
         },
         {


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*

<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
